### PR TITLE
Add DataInput::Fieldset Component

### DIFF
--- a/.windsurf/rules/committing.md
+++ b/.windsurf/rules/committing.md
@@ -5,7 +5,7 @@ When committing code changes, follow these procedures.
 1. NEVER attempt to commit unless requested.
 
 2. MUST follow these commit steps in series:
-  a. Run `make loco-test` to ensure all tests pass.
+  a. Run `make loco-test` and `make demo-test` to ensure all tests pass.
   b. Run a `git status --porcelain` to see what files changed.
   c. MUST run `git add .` to stage all changes in the working directory and index.
   d. Run `git diff --staged` to see the changes of all staged files.

--- a/.windsurf/rules/creating_a_pull_request.md
+++ b/.windsurf/rules/creating_a_pull_request.md
@@ -16,13 +16,10 @@ When asked to create a Pull Request (PR), follow these procedures:
 
 5.  MUST format the PR description using Markdown.
 
-6.  MUST provide the generated description as a code snippet that the user can
-    easily copy/paste into GitHub.
+6.  MUST present the PR description as a code snippet to the user for review and
+potential modification before proceeding.
 
-7.  MUST present the generated description to the user for review and potential
-    modification before proceeding.
-
-8.  MUST update the `CHANGELOG.md`:
+7.  MUST update the `CHANGELOG.md`:
     a. Generate a concise summary of changes based on the commit messages in
        the current branch (similar to the PR description in Rule 6).
     b. Check if an `[Unreleased]` section exists at the top of the
@@ -31,9 +28,9 @@ When asked to create a Pull Request (PR), follow these procedures:
     d. If it does not exist, create the `[Unreleased]` section header at the
        top and add the summary list items beneath it.
 
-9.  MUST run `git add .` to add the `CHANGELOG.md` changes.
+8.  MUST run `git add .` to add the `CHANGELOG.md` changes.
 
-10. MUST commit the `CHANGELOG.md` changes with the message
+9.  MUST commit the `CHANGELOG.md` changes with the message
     `'docs: Update CHANGELOG'`, using single quotes.
 
-11. MUST push the `CHANGELOG.md` commit to the remote repository.
+10. MUST push the `CHANGELOG.md` commit to the remote repository.

--- a/.windsurf/rules/planning.md
+++ b/.windsurf/rules/planning.md
@@ -2,6 +2,9 @@
 
 When asked to create a plan, follow these procedures.
 
+0. If we are on the main branch, MUST review any provided GitHub issues and create a branch with a relevant name.
+   a. Branch names MUST follow the pattern of `type-ISSUE_NUMBER-short-description` (ex: `feat-123-add-foo-component` or `fix-456-typo-in-docs`)
+
 1. MUST review the template specified by the user, or the default plan template
    if none is specified. Templates are located in the `docs/plans/templates`
    directory.
@@ -12,6 +15,12 @@ When asked to create a plan, follow these procedures.
 
 4. MUST include exact links provided by the user.
 
-5. NEVER add component variants unless explicitly requested.
+5. MUST review any links in provided GitHub issues.
 
-6. MUST pause after creating the plan so user can review.
+6. MUST wrap lines at 80 characters.
+
+7. NEVER add component variants unless explicitly requested.
+
+8. MUST pause after creating the plan so user can review.
+
+9. NEVER execute a plan unless explicitly requested.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Read on for specific changes across the entire project! :tada:
 
 - add(`where:`): Add custom `where:` Tailwind modifier
 - add(List): Add basic List component with examples and specs ([Fixes #29](https://github.com/profoundry-us/loco_motion/issues/29))
+- add(Fieldset): Add Fieldset component for grouping related form elements ([Fixes #32](https://github.com/profoundry-us/loco_motion/issues/32))
 - feat(LabelableComponent): New concern to enable label functionality across components
 - feat(Select): Enable start/end/floating label functionality
 - feat(Toggle): Enable start/end/floating label functionality

--- a/app/components/daisy/data_input/fieldset_component.html.haml
+++ b/app/components/daisy/data_input/fieldset_component.html.haml
@@ -1,0 +1,8 @@
+= part(:component) do
+  - if legend?
+    = legend
+  - elsif @simple_legend
+    = part(:legend) { @simple_legend }
+
+  -# Render the main content passed to the component block
+  = content

--- a/app/components/daisy/data_input/fieldset_component.rb
+++ b/app/components/daisy/data_input/fieldset_component.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Daisy
+  module DataInput
+    # Renders a fieldset element, optionally with a legend, to group
+    # related form controls or content.
+    #
+    # @example Basic fieldset
+    #   = daisy_fieldset do
+    #     Content inside fieldset
+    #
+    # @example Fieldset with legend slot
+    #   = daisy_fieldset do |fieldset|
+    #     - fieldset.with_legend { "My Legend" }
+    #
+    #     Content inside fieldset
+    #
+    # @example Fieldset with legend argument
+    #   = daisy_fieldset(legend: "My Legend") do
+    #     Content inside fieldset
+    #
+    class FieldsetComponent < LocoMotion::BaseComponent
+      self.component_name = :fieldset
+
+      define_parts :legend
+
+      # The legend (title) for the fieldset. Renders a `<legend>` tag.
+      # Can be provided as a slot or via the `legend` argument.
+      renders_one :legend, LocoMotion::BasicComponent.build(tag_name: :legend, css: "fieldset-legend")
+
+      # @param legend [String] Optional simple text for the legend.
+      #   Ignored if the `legend` slot is used.
+      def initialize(legend: nil, **kws)
+        @simple_legend = legend
+
+        super(**kws)
+      end
+
+      def before_render
+        setup_component
+
+        super
+      end
+
+      private
+
+      # Sets up default tags and classes for the component and its parts.
+      def setup_component
+        set_tag_name(:component, :fieldset)
+        set_tag_name(:legend, :legend)
+
+        add_css(:legend, "fieldset-legend")
+        add_css(:component, "fieldset")
+      end
+    end
+  end
+end

--- a/docs/demo/app/views/examples/daisy/data_input/fieldsets.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/fieldsets.html.haml
@@ -1,0 +1,59 @@
+= doc_title(title: "Fieldsets", comp: @comp) do |title|
+  :markdown
+    Fieldsets group related form controls and can optionally include a legend.
+
+= doc_example(title: "Basic Fieldset (No Legend)") do |doc|
+  - doc.with_description do
+    :markdown
+      A simple fieldset rendered without a legend.
+
+  = daisy_fieldset do
+    = daisy_toggle(end: "Enable Feature X")
+
+
+= doc_example(title: "Fieldset with Legend (Argument)") do |doc|
+  - doc.with_description do
+    :markdown
+      Pass simple text for the legend directly using the `legend:` argument.
+
+  = daisy_fieldset(legend: "Settings (Argument)") do
+    = daisy_toggle(end: "Enable Feature X")
+
+
+= doc_example(title: "Fieldset with Legend (Slot)") do |doc|
+  - doc.with_description do
+    :markdown
+      Use the `with_legend` slot to provide custom content for the legend,
+      including HTML.
+
+  = daisy_fieldset do |fieldset|
+    - fieldset.with_legend { "Settings (Slot)" }
+
+    = daisy_toggle(end: "Enable Notifications")
+    = daisy_toggle(end: "Enable Dark Mode")
+
+
+= doc_example(title: "Fieldset with Various Inputs") do |doc|
+  - doc.with_description do
+    :markdown
+      Fieldsets are useful for grouping related form inputs under a common legend.
+
+  = daisy_fieldset(legend: "User Profile") do
+    .mt-4.space-y-4
+      = daisy_input(floating: "Name")
+      = daisy_text_area(floating: "Bio", rows: 3)
+      = daisy_select(floating: "Country", options: ["USA", "Canada", "Mexico"])
+
+
+= doc_example(title: "Fieldset with Custom Styling") do |doc|
+  - doc.with_description do
+    :markdown
+      You can customize the Fieldset with standard `css` options to make it look
+      exactly like you want.
+
+  = daisy_fieldset(css: "p-4 border rounded bg-base-200 w-80") do |fieldset|
+    - fieldset.with_legend(css: "border rounded bg-white px-4") { "Advanced Options" }
+
+    = daisy_label("API Key")
+    = daisy_input(placeholder: "asdf1234")
+    = daisy_button("Save Settings", css: "mt-4")

--- a/docs/plans/add_fieldset_component.md
+++ b/docs/plans/add_fieldset_component.md
@@ -1,0 +1,238 @@
+# Fieldset Component Implementation Plan
+
+## Overview
+
+This plan outlines the steps to implement the DaisyUI Fieldset component in the
+LocoMotion library as part of the DataInput group. The Fieldset component provides
+a way to group related form elements visually, often including a legend (title).
+This component corresponds to issue
+[#32](https://github.com/profoundry-us/loco_motion/issues/32).
+
+## External Resources
+
+- [DaisyUI Fieldset Component](https://daisyui.com/components/fieldset/)
+- [Rails View Components Guide](https://viewcomponent.org/guide/)
+
+## Implementation Steps
+
+### 1. Create the Component Class
+
+**Purpose**: Define the core component class, including slots for legend and
+basic setup.
+
+**Slots**:
+- `renders_one :legend` (Optional): Renders the `<legend>` element.
+
+**File to Create**: `app/components/daisy/data_input/fieldset_component.rb`
+
+**Reference Files**:
+- `app/components/daisy/data_input/input_component.rb`
+- `app/components/daisy/data_input/select_component.rb`
+
+**Example Implementation**:
+
+```ruby
+module Daisy
+  module DataInput
+    # Renders a fieldset element, optionally with a legend, to group
+    # related form controls or content.
+    #
+    # @example Basic fieldset
+    #   = render Daisy::DataInput::FieldsetComponent.new do
+    #     Content inside fieldset
+    #
+    # @example Fieldset with legend slot
+    #   = render Daisy::DataInput::FieldsetComponent.new do |c|
+    #     - c.with_legend { "My Legend" }
+    #     Content inside fieldset
+    #
+    # @example Fieldset with legend argument
+    #   = render Daisy::DataInput::FieldsetComponent.new(legend: "My Legend") do
+    #     Content inside fieldset
+    #
+    class FieldsetComponent < LocoMotion::BaseComponent
+      self.component_name = :fieldset
+
+      define_parts :legend
+
+      # The legend (title) for the fieldset. Renders a `<legend>` tag.
+      # Can be provided as a slot or via the `legend` argument.
+      renders_one :legend, LocoMotion::BasicComponent.build(tag_name: :legend, css: "fieldset-legend")
+
+      # @param legend [String] Optional simple text for the legend.
+      #   Ignored if the `legend` slot is used.
+      def initialize(legend: nil, **kws)
+        @simple_legend = legend
+        super(**kws)
+      end
+
+      def before_render
+        setup_component
+        super
+      end
+
+      private
+
+      # Sets up default tags and classes for the component and its parts.
+      def setup_component
+        set_tag_name(:component, :fieldset)
+        set_tag_name(:legend, :legend)
+        add_css(:legend, "fieldset-legend")
+        # No specific base DaisyUI class for fieldset itself.
+        # Styling comes from legend/label classes and utilities applied.
+      end
+    end
+  end
+end
+
+```
+
+### 2. Create Component View
+
+**Purpose**: Provide the standard HTML structure using HAML, rendering the
+legend and main content block.
+
+**File to Create**: `app/components/daisy/data_input/fieldset_component.html.haml`
+
+**Reference Files**:
+- `app/components/daisy/data_input/input_component.html.haml`
+- `app/components/daisy/data_input/select_component.html.haml`
+
+**Example Implementation**:
+
+```haml
+= part(:component) do
+  - if legend?
+    = legend
+  - elsif @simple_legend
+    = part(:legend) { @simple_legend }
+
+  -# Render the main content passed to the component block
+  = content
+```
+
+### 3. Create Component Specs
+
+**Purpose**: Ensure component functionality works as expected, including
+rendering with/without slots and applying custom classes.
+
+**File to Create**: `spec/components/daisy/data_input/fieldset_component_spec.rb`
+
+**Reference Files**:
+- `spec/components/daisy/data_input/input_component_spec.rb`
+- `spec/components/daisy/data_input/select_component_spec.rb`
+
+**Example Implementation**:
+
+```ruby
+require "rails_helper"
+
+RSpec.describe Daisy::DataInput::FieldsetComponent, type: :component do
+  it "renders basic fieldset with content" do
+    render_inline(described_class.new) do
+      "Fieldset Content"
+    end
+    expect(page).to have_selector("fieldset", text: "Fieldset Content")
+    expect(page).not_to have_selector("legend.fieldset-legend")
+  end
+
+  it "renders with legend slot" do
+    render_inline(described_class.new) do |c|
+      c.with_legend { "My Legend Slot" }
+      "Fieldset Content"
+    end
+    expect(page).to have_selector("fieldset legend.fieldset-legend", text: "My Legend Slot")
+  end
+
+  it "renders with legend argument" do
+    render_inline(described_class.new(legend: "My Simple Legend")) do
+      "Fieldset Content"
+    end
+    expect(page).to have_selector("fieldset legend.fieldset-legend", text: "My Simple Legend")
+  end
+
+  it "prioritizes legend slot over argument" do
+    render_inline(described_class.new(legend: "My Simple Legend")) do |c|
+      c.with_legend { "My Legend Slot" }
+      "Fieldset Content"
+    end
+    expect(page).to have_selector("fieldset legend.fieldset-legend", text: "My Legend Slot")
+    expect(page).not_to have_selector("fieldset legend.fieldset-legend", text: "My Simple Legend")
+  end
+
+  it "applies custom CSS classes" do
+    render_inline(described_class.new(class: "my-custom-class p-4")) do
+      "Fieldset Content"
+    end
+    expect(page).to have_selector("fieldset.my-custom-class.p-4")
+  end
+
+  it "accepts standard HTML attributes" do
+    render_inline(described_class.new(id: "my-id", data: { test: "value" })) do
+      "Fieldset Content"
+    end
+    expect(page).to have_selector("fieldset#my-id[data-test='value']")
+  end
+end
+```
+
+### 4. Create Example View
+
+**Purpose**: Provide usage examples and visual demonstration of the component
+in the demo application.
+
+**File to Create**: `docs/demo/app/views/examples/daisy/data_input/fieldsets.html.haml`
+
+**Reference Files**:
+- `docs/demo/app/views/examples/daisy/layout/cards.html.haml`
+- `docs/demo/app/views/examples/daisy/layout/stacks.html.haml`
+
+### 5. Register the Helper
+
+**Purpose**: Make the component available to the application via a helper
+method (`daisy_fieldset`).
+
+**File to Edit**: `lib/loco_motion/helpers.rb`
+
+**Reference Files**:
+- Existing helper registrations in `lib/loco_motion/helpers.rb`
+
+**Example Implementation**:
+
+```ruby
+module LocoMotion
+  module Helpers
+    # {{ ... existing helper code ... }}
+
+    # Registers the Daisy::DataInput::FieldsetComponent under the helper name :fieldset
+    register_component :fieldset, Daisy::DataInput::FieldsetComponent
+
+    # {{ ... more existing helper code ... }}
+  end
+end
+```
+
+## Component Features and Options
+
+The Fieldset component will support:
+
+1. Rendering a standard HTML `<fieldset>` element.
+2. An optional `legend` slot **or** `legend` argument to render a `<legend>`
+   with the `fieldset-legend` class. (Slot takes precedence).
+3. Rendering provided block content within the fieldset.
+4. Accepting standard HTML attributes and Tailwind/DaisyUI utility classes.
+
+## Example Usage
+
+```haml
+= daisy_fieldset(legend: "User Settings") do
+  = daisy_input_group(label: "Username") do
+    = text_field_tag :username, nil, class: "input input-bordered"
+  = daisy_input_group(label: "Email") do
+    = email_field_tag :email, nil, class: "input input-bordered"
+```
+
+```haml
+= daisy_fieldset(class: "bg-base-200 border border-base-300 p-4 rounded-box") do
+  = daisy_input_group(label: "Notification Settings") do
+    = daisy_toggle(label: "Enable email notifications")

--- a/docs/plans/templates/new_component.md
+++ b/docs/plans/templates/new_component.md
@@ -2,12 +2,17 @@
 
 ## Overview
 
-This is a simplified template for implementing new components in the LocoMotion library. Each step includes:
+This is a simplified template for implementing new components in the LocoMotion
+library. Each step includes:
+
 1. A short sentence about the purpose of the file
 2. The file to create
 3. Two existing files to use as reference
+4. Any additional notes about that specific file.
+5. A code example showing how we might implement that file.
 
-Below is an example implementation plan for a fictional `FakeComponent` in the `DataInput` module.
+Below is an example implementation plan for a fictional `FakeComponent` in the
+`DataInput` module.
 
 ## External Resources
 
@@ -18,7 +23,20 @@ Below is an example implementation plan for a fictional `FakeComponent` in the `
 
 ### 1. Create the Component Class
 
-**Purpose**: Define the core component class that handles rendering and configuration.
+**Purpose**: Define the core component class, including rendering,
+configuration, and any necessary parts or slots.
+
+**Parts**:
+
+- label: For displaying a label.
+- icon: For adding an icon.
+- items (Multiple): For list-like components.
+- caption: For displaying a caption.
+
+**Slots**:
+
+- top: For content above the main content of the component.
+- bottom: For content below the main content of the component.
 
 **File to Create**: `app/components/daisy/data_input/fake_component.rb`
 
@@ -26,15 +44,116 @@ Below is an example implementation plan for a fictional `FakeComponent` in the `
 - `app/components/daisy/data_input/checkbox_component.rb`
 - `app/components/daisy/data_input/range_component.rb`
 
+**Example Implementation**:
+
+```ruby
+module Daisy
+  module DataInput
+    class FakeComponent < LocoMotion::BaseComponent
+      self.component_name = "fake"
+
+      part :label
+      part :icon
+      part :items, multiple: true
+      part :caption
+
+      renders_one :top
+      renders_one :bottom
+
+      # @param name [String] Required identifier for the component.
+      # @param simple_caption [String] Optional simple caption text displayed below the component.
+      #   For more complex content, use the `with_caption` slot.
+      def initialize(name:, simple_caption: nil, **system_arguments)
+        @name = name
+        @simple_caption = simple_caption
+        super(**system_arguments)
+      end
+
+      def before_render
+        setup_component
+        super # Call super after setup
+      end
+
+      private
+
+      def setup_component
+        # Add base component class
+        add_css(:component, "fake")
+
+        # Add data attribute if caption is present (either via part or simple_caption)
+        add_html(:component, { data: { captioned: true } }) if caption? || @simple_caption
+
+        # Set default tag if not already set (e.g., by LinkableComponent)
+        set_tag_name(:component, :div)
+
+        # Add standard data attributes
+        add_html(:component, { data: { name: @name } })
+      end
+    end
+  end
+end
+```
+
+### 2.1. Create Component View
+
+**Purpose**: Provide a standard HTML structure for the component.
+
+**File to Create**: `app/components/daisy/data_input/fake_component.html.haml`
+
+**Reference Files**:
+- `app/components/daisy/data_input/checkbox_component.html.haml`
+- `app/components/daisy/data_input/range_component.html.haml`
+
+**Example Implementation**:
+
+```haml
+= top if top?
+
+= part(:component) do
+  = part(:label)
+  = part(:icon)
+  - part(:items).each do |item|
+    = item
+
+- if caption?
+  = caption
+- elsif @simple_caption
+  = part(:caption) do
+    = @simple_caption
+
+= bottom if bottom?
+```
+
 ### 2. Create Component Tests
 
-**Purpose**: Ensure component functionality works as expected through comprehensive test cases.
+**Purpose**: Ensure component functionality works as expected through
+comprehensive test cases.
 
 **File to Create**: `spec/components/daisy/data_input/fake_component_spec.rb`
 
 **Reference Files**:
 - `spec/components/daisy/data_input/checkbox_component_spec.rb`
 - `spec/components/daisy/data_input/range_component_spec.rb`
+
+**Example Implementation**:
+
+```ruby
+RSpec.describe Daisy::DataInput::FakeComponent, type: :component do
+  it "renders basic component" do
+    render_inline(described_class.new(name: "my_fake"))
+    expect(page).to have_css(".fake")
+  end
+
+  it "renders with label and icon" do
+    render_inline(described_class.new(name: "my_fake")) do |c|
+      c.with_label { "My Label" }
+      c.with_icon { "fake-icon" }
+    end
+    expect(page).to have_text("My Label")
+    expect(page).to have_css(".fake-icon")
+  end
+end
+```
 
 ### 3. Create Example Views
 
@@ -46,15 +165,45 @@ Below is an example implementation plan for a fictional `FakeComponent` in the `
 - `docs/demo/app/views/examples/daisy/data_input/checkboxes.html.haml`
 - `docs/demo/app/views/examples/daisy/data_input/ranges.html.haml`
 
+**Example Implementation**:
+
+```haml
+= doc_example(title: "Basic Fake") do
+  = daisy_fake(name: "basic")
+
+= doc_example(title: "Fake with Label and Icon") do
+  = daisy_fake(name: "labelled") do |c|
+    - c.with_label { "Click Me" }
+    - c.with_icon { "star" }
+```
+
 ### 4. Update Form Builder Helper
 
-**Purpose**: Add form builder integration to allow usage with Rails form builders.
+**Purpose**: Add form builder integration to allow usage with Rails form
+builders.
 
 **File to Edit**: `app/helpers/daisy/form_builder_helper.rb`
 
 **Reference Files**:
 - Current implementation in `app/helpers/daisy/form_builder_helper.rb` (checkbox methods)
 - Current implementation in `app/helpers/daisy/form_builder_helper.rb` (range methods)
+
+**Example Implementation**:
+
+```ruby
+module Daisy
+  module FormBuilderHelper
+    def fake_field(method, options = {}, &block)
+      component = Daisy::DataInput::FakeComponent.new(
+        name: method,
+        **options.slice(:class, :css, :data, :id) # Add other relevant options
+      )
+      # Additional logic might be needed to handle value, checked state, etc.
+      render component, &block
+    end
+  end
+end
+```
 
 ### 5. Update Form Builder Helper Specs
 
@@ -66,6 +215,19 @@ Below is an example implementation plan for a fictional `FakeComponent` in the `
 - Current specs in `spec/helpers/daisy/form_builder_helper_spec.rb` (checkbox specs)
 - Current specs in `spec/helpers/daisy/form_builder_helper_spec.rb` (range specs)
 
+**Example Implementation**:
+
+```ruby
+describe "#fake_field" do
+  it "renders the fake component" do
+    render_form_for @user do |f|
+      f.fake_field :agreed_to_terms
+    end
+    expect(page).to have_css(".fake[name='user[agreed_to_terms]']")
+  end
+end
+```
+
 ### 6. Register the Helper
 
 **Purpose**: Make the component available to the application by registering it.
@@ -75,3 +237,19 @@ Below is an example implementation plan for a fictional `FakeComponent` in the `
 **Reference Files**:
 - Current implementation in `lib/loco_motion/helpers.rb` (checkbox registration)
 - Current implementation in `lib/loco_motion/helpers.rb` (range registration)
+
+**Example Implementation**:
+
+```ruby
+module LocoMotion
+  module Helpers
+    # ... existing helpers ...
+
+    def daisy_fake(name:, **options, &block)
+      render Daisy::DataInput::FakeComponent.new(name: name, **options), &block
+    end
+
+    # ... other helper registrations ...
+    register_helpers self, :daisy_fake
+  end
+end

--- a/lib/loco_motion/helpers.rb
+++ b/lib/loco_motion/helpers.rb
@@ -33,6 +33,7 @@ module LocoMotion
     # Data Input
     "Daisy::DataInput::CheckboxComponent" => { names: "checkbox", group: "Data Input", title: "Checkboxes", example: "checkboxes" },
     "Daisy::DataInput::FileInputComponent" => { names: "file_input", group: "Data Input", title: "File Inputs", example: "file_inputs" },
+    "Daisy::DataInput::FieldsetComponent" => { names: "fieldset", group: "Data Input", title: "Fieldsets", example: "fieldsets" },
     "Daisy::DataInput::LabelComponent" => { names: "label", group: "Data Input", title: "Labels", example: "labels" },
     "Daisy::DataInput::RadioButtonComponent" => { names: "radio", group: "Data Input", title: "Radio Buttons", example: "radio_buttons" },
     "Daisy::DataInput::RangeComponent" => { names: "range", group: "Data Input", title: "Ranges", example: "ranges" },

--- a/spec/components/daisy/data_input/fieldset_component_spec.rb
+++ b/spec/components/daisy/data_input/fieldset_component_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Daisy::DataInput::FieldsetComponent, type: :component do
+  it "renders with content" do
+    render_inline(described_class.new) do
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("fieldset", text: "Fieldset Content")
+    expect(page).not_to have_css("legend.fieldset-legend")
+  end
+
+  it "renders with legend slot" do
+    render_inline(described_class.new) do |c|
+      c.with_legend { "My Legend Slot" }
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("fieldset legend.fieldset-legend", text: "My Legend Slot")
+  end
+
+  it "renders with legend argument" do
+    render_inline(described_class.new(legend: "My Simple Legend")) do
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("fieldset legend.fieldset-legend", text: "My Simple Legend")
+  end
+
+  it "prioritizes legend slot over argument" do
+    render_inline(described_class.new(legend: "My Simple Legend")) do |c|
+      c.with_legend { "My Legend Slot" }
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("fieldset legend.fieldset-legend", text: "My Legend Slot")
+    expect(page).not_to have_css("fieldset legend.fieldset-legend", text: "My Simple Legend")
+  end
+
+  it "applies custom CSS classes" do
+    render_inline(described_class.new(css: "my-custom-class p-4")) do
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("fieldset.my-custom-class")
+    expect(page).to have_css("fieldset.p-4")
+  end
+
+  it "accepts arbitrary HTML attributes" do
+    render_inline(described_class.new(html: { id: "my-id", data: { foo: "test" } })) do
+      "Fieldset Content"
+    end
+
+    expect(page).to have_css("fieldset[id='my-id'][data-foo='test']")
+  end
+
+  it "renders the legend part with default classes when simple legend is provided" do
+    render_inline(described_class.new(legend: "Simple Part Legend")) do
+      "Content"
+    end
+    expect(page).to have_css("legend.fieldset-legend", text: "Simple Part Legend")
+  end
+
+  it "allows customizing the legend part" do
+    render_inline(described_class.new(legend: "Simple Legend")) do |fieldset|
+      fieldset.with_legend(css: "custom-legend-class") { "Simple Legend" }
+      "Content"
+    end
+
+    expect(page).to have_css("legend.fieldset-legend.custom-legend-class", text: "Simple Legend")
+  end
+end


### PR DESCRIPTION
## Context

This PR adds a new Fieldset component to the DataInput group. Fieldsets provide a way to group related form elements with an optional legend (title).

## Related Issues

Fixes #32

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Component update/addition
- [x] Documentation update

## Description

Implements the Fieldset component that:
- Groups related form controls or content within a semantic HTML fieldset element
- Supports an optional legend (title) for the group
- Can accept a legend via a slot or as a simple text parameter
- Follows the existing component patterns for styling and API consistency

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser
- [x] I have added appropriate YARD documentation
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements

## Additional Notes

This component provides a semantic way to group related form elements, improving both accessibility and organization of complex forms.