### PR TITLE
Feat 31 add calendar component

### DIFF
--- a/.windsurf/rules/creating_a_pull_request.md
+++ b/.windsurf/rules/creating_a_pull_request.md
@@ -1,3 +1,7 @@
+---
+trigger: manual
+---
+
 # Creating a Pull Request
 
 When asked to create a Pull Request (PR), follow these procedures:
@@ -11,15 +15,14 @@ When asked to create a Pull Request (PR), follow these procedures:
 3.  MUST run `git log --oneline main..HEAD` to see a comprehensive list of all
     changes since branching from `main`.
 
-4.  MUST include relevant lines based on the commit history in the PR
-    description.
+4.  MUST format the PR description using Markdown.
+  - include relevant lines based on the commit history in the PR description
+  - Use the format `Fixes #123` for the Related Issue
+  - Find the issue number contained in the current branch
 
-5.  MUST format the PR description using Markdown.
+5.  MUST present the PR description as a code snippet to the user for review and potential modification before proceeding.
 
-6.  MUST present the PR description as a code snippet to the user for review and
-potential modification before proceeding.
-
-7.  MUST update the `CHANGELOG.md`:
+6.  MUST update the `CHANGELOG.md`:
     a. Generate a concise summary of changes based on the commit messages in
        the current branch (similar to the PR description in Rule 6).
     b. Check if an `[Unreleased]` section exists at the top of the
@@ -28,9 +31,9 @@ potential modification before proceeding.
     d. If it does not exist, create the `[Unreleased]` section header at the
        top and add the summary list items beneath it.
 
-8.  MUST run `git add .` to add the `CHANGELOG.md` changes.
+7.  MUST run `git add .` to add the `CHANGELOG.md` changes.
 
-9.  MUST commit the `CHANGELOG.md` changes with the message
+8.  MUST commit the `CHANGELOG.md` changes with the message
     `'docs: Update CHANGELOG'`, using single quotes.
 
-10. MUST push the `CHANGELOG.md` commit to the remote repository.
+9. MUST push the `CHANGELOG.md` commit to the remote repository.

--- a/.windsurf/rules/documenting_code.md
+++ b/.windsurf/rules/documenting_code.md
@@ -1,3 +1,7 @@
+---
+trigger: manual
+---
+
 # Documenting Code
 
 When documenting code, follow these procedures.
@@ -5,22 +9,32 @@ When documenting code, follow these procedures.
 1. MUST utilize YARD documentation for Ruby files.
 
 2. When documenting new components, MUST utilize existing components as a guide.
+   a. Check similar components (e.g., `CardComponent` for UI components) for patterns
 
 3. If a component uses `define_part` or `define_parts`, MUST use the `@part`
    macro to document it.
+   a. Include a brief description of what the part represents
+   b. Use the format: `@part name - Description of the part's purpose`
 
 4. If a component uses `renders_one` or `renders_many`:
    a. MUST use the `@slot` macro to document it.
+   b. Include the slot's type in square brackets (e.g., `[ComponentClass]`)
+   c. Describe the slot's purpose and any default behavior
+   d. Use `@see` to reference related methods when applicable
 
 5. If a component uses `renders_many`:
    a. MUST use the `+` symbol after the name to indicate that it allows multiple
-      calls.
+      calls (e.g., `@slot items+`)
 
 6. When documenting a component:
    a. ONLY use `@param` for positional arguments and `@option` for all other
    keyword arguments.
+   b. Document all parameters in the `initialize` method, not in the class documentation
 
 7. All loco_examples in the YARD documentation MUST use proper HAML syntax.
+   a. Examples should demonstrate common use cases
+   b. Include examples for different configurations and edge cases
+   c. Use descriptive titles for each example
 
 8. When adding a TODO item:
    a. MUST append it to the bottom of the list in the `README.md` file
@@ -31,18 +45,39 @@ When documenting code, follow these procedures.
     include them in the `@param` YARD documentation.
 
 11. All `@param` and `@option` YARD documentation MUST be on the `initialize`
-    method.
+    method, not in the class documentation.
 
 12. All `@param` and `@option` YARD documentation MUST have newlines between
     them.
 
 13. Follow this order when writing component YARD documentation:
-  a. Description
-  b. Notes (Optional)
-  c. Parts
-  d. Slots
-  e. Examples
+    a. Description - Brief explanation of the component's purpose
+    b. Notes (Optional) - Any important notes or warnings about the component
+    c. Parts - Documented with `@part`
+    d. Slots - Documented with `@slot`
+    e. Examples - Documented with `@loco_example`
 
-14. MUST use `@loco_example` to document our YARD examples.
+14. MUST use `@loco_example` instead of `@example` to document our YARD examples.
+    a. Each example should have a descriptive title
+    b. Examples should be ordered from simplest to most complex
+    c. Include examples for different configurations and use cases
 
 15. MUST wrap lines at 80 characters.
+
+16. For component documentation:
+    a. Keep the class-level documentation focused on the component's purpose and structure
+    b. Move parameter documentation to the `initialize` method
+    c. Include a `@note` section for important behavioral notes when necessary
+    d. Reference related components when appropriate
+
+17. For slot documentation:
+    a. Include the slot's type in square brackets
+    b. Describe the slot's purpose and any default behavior
+    c. Use `@see` to reference related methods
+    d. For slots with default content, mention what the default is
+
+18. For example formatting:
+    a. Use descriptive titles that explain what the example demonstrates
+    b. Order examples from simplest to most complex
+    c. Include examples for different configurations and edge cases
+    d. Keep examples focused and concise

--- a/.windsurf/rules/updating_the_changelog.md
+++ b/.windsurf/rules/updating_the_changelog.md
@@ -5,9 +5,13 @@ When modifying the `CHANGELOG.md` file, follow these procedures regarding format
 1. MUST review the existing `CHANGELOG.md` content to ensure consistency with
    the established format.
 
-2. MUST ensure new entries are added as list items under the correct section
-   header (`[Unreleased]` or a specific version header like
+2. MUST ensure new entries are added as items to the bottom of the list under
+   the correct section header (`[Unreleased]` or a specific version header like
    `## [X.Y.Z] - YYYY-MM-DD`).
+    a. doc_note components and changes should always go under the "Demo / Docs
+       Changes" section
+    b. component changes should always go under the "Components Changes" section
+    c. general changes should always go under the "General Changes" section
 
 3. MUST maintain the link reference definitions at the bottom of the file when
    adding new version sections.

--- a/.windsurf/workflows/new_component_workflow.md
+++ b/.windsurf/workflows/new_component_workflow.md
@@ -6,23 +6,29 @@ description: Create the stubs for a new component.
 
 ## Overview
 
-This workflow guides the AI through creating basic stub files for a new LocoMotion component. The goal is to create minimal file templates without attempting to guess complex implementation details.
+This workflow guides the AI through creating basic stub files for a new LocoMotion
+component. The goal is to create minimal file templates without attempting to guess
+complex implementation details.
 
 ## Input Parameters
 
-- `component_name`: The name of the component in snake_case (e.g., `text_input`)
-- `component_group`: The component group (e.g., `data_input`, `data_display`, `layout`, `navigation`, `feedback`)
+- `component_name`: The name of the component in snake_case
+  (e.g., `text_input`)
+- `component_group`: The component group
+  (e.g., `data_input`, `data_display`, `layout`, `navigation`, `feedback`)
 
 ## Steps
 
 ### 1. Validate Inputs
 
 - Ensure both `component_name` and `component_group` are provided
-- Verify that `component_group` is one of the valid groups: `data_input`, `data_display`, `layout`, `navigation`, `feedback`
+- Verify that `component_group` is one of the valid groups:
+  `data_input`, `data_display`, `layout`, `navigation`, `feedback`
 
 ### 2. Create Component Class File
 
-**File path**: `app/components/daisy/{component_group}/{component_name}_component.rb`
+**File path**:
+`app/components/daisy/{component_group}/{component_name}_component.rb`
 
 **Content template**:
 
@@ -33,8 +39,8 @@ module Daisy
       self.component_name = "{component_name}"
 
       # Define parts here (empty by default)
-      # part :label
-      # part :icon
+      # define_part :label
+      # define_part :icon
 
       def initialize(**kws)
         super(**kws)
@@ -61,7 +67,8 @@ Where:
 
 ### 3. Create Component Template File
 
-**File path**: `app/components/daisy/{component_group}/{component_name}_component.html.haml`
+**File path**:
+`app/components/daisy/{component_group}/{component_name}_component.html.haml`
 
 **Content template**:
 
@@ -73,7 +80,8 @@ Where:
 
 ### 4. Create Component Test File
 
-**File path**: `spec/components/daisy/{component_group}/{component_name}_component_spec.rb`
+**File path**:
+`spec/components/daisy/{component_group}/{component_name}_component_spec.rb`
 
 **Content template**:
 
@@ -92,10 +100,13 @@ Where:
 
 ### 5. Create Example File
 
-**File path**: `docs/demo/app/views/examples/daisy/{component_group}/{plural_component_name}.html.haml`
+**File path**:
+`docs/demo/app/views/examples/daisy/{component_group}/{plural_component_name}.html.haml`
 
 Where:
-- `{plural_component_name}` is the pluralized component name (e.g., if component_name is "button", use "buttons"; if it's "entry", use "entries")
+- `{plural_component_name}` is the pluralized component name (e.g.,
+  if component_name is "button", use "buttons";
+  if it's "entry", use "entries")
 
 **IMPORTANT RULES**:
 - MUST add a doc_title section with TODO text
@@ -134,12 +145,18 @@ make demo-restart
 
 **File path**: `lib/loco_motion/helpers.rb`
 
-Add the component to the `COMPONENTS` hash in `helpers.rb`. Find the appropriate section based on the component group and add a new entry.
+Add the component to the `COMPONENTS` hash in `helpers.rb`. Find the appropriate
+section based on the component group and add a new entry.
 
 **Example entry to add**:
 
 ```ruby
-"Daisy::{ModuleName}::{ClassName}Component" => { names: "{component_name}", group: "{GroupDisplay}", title: "{PluralTitle}", example: "{plural_component_name}" },
+"Daisy::{ModuleName}::{ClassName}Component" => {
+  names: "{component_name}",
+  group: "{GroupDisplay}",
+  title: "{PluralTitle}",
+  example: "{plural_component_name}"
+},
 ```
 
 Where:
@@ -164,11 +181,16 @@ When you use this workflow to create a component, report back with a structure l
 ```
 I've created the following stub files for the new {ComponentName} component:
 
-1. Component class: `app/components/daisy/{component_group}/{component_name}_component.rb`
-2. Component template: `app/components/daisy/{component_group}/{component_name}_component.html.haml`
-3. Component spec: `spec/components/daisy/{component_group}/{component_name}_component_spec.rb`
-4. Example file: `docs/demo/app/views/examples/daisy/{component_group}/{plural_component_name}.html.haml`
-5. Added the component registration to: `lib/loco_motion/helpers.rb`
+1. Component class:
+   `app/components/daisy/{component_group}/{component_name}_component.rb`
+2. Component template:
+   `app/components/daisy/{component_group}/{component_name}_component.html.haml`
+3. Component spec:
+   `spec/components/daisy/{component_group}/{component_name}_component_spec.rb`
+4. Example file:
+   `docs/demo/app/views/examples/daisy/{component_group}/{plural_component_name}.html.haml`
+5. Added the component registration to:
+   `lib/loco_motion/helpers.rb`
 
 I've also restarted the demo app to make the new component available.
 

--- a/.windsurf/workflows/new_component_workflow.md
+++ b/.windsurf/workflows/new_component_workflow.md
@@ -1,0 +1,180 @@
+---
+description: Create the stubs for a new component.
+---
+
+# New Component Workflow
+
+## Overview
+
+This workflow guides the AI through creating basic stub files for a new LocoMotion component. The goal is to create minimal file templates without attempting to guess complex implementation details.
+
+## Input Parameters
+
+- `component_name`: The name of the component in snake_case (e.g., `text_input`)
+- `component_group`: The component group (e.g., `data_input`, `data_display`, `layout`, `navigation`, `feedback`)
+
+## Steps
+
+### 1. Validate Inputs
+
+- Ensure both `component_name` and `component_group` are provided
+- Verify that `component_group` is one of the valid groups: `data_input`, `data_display`, `layout`, `navigation`, `feedback`
+
+### 2. Create Component Class File
+
+**File path**: `app/components/daisy/{component_group}/{component_name}_component.rb`
+
+**Content template**:
+
+```ruby
+module Daisy
+  module {ModuleName}
+    class {ClassName}Component < LocoMotion::BaseComponent
+      self.component_name = "{component_name}"
+
+      # Define parts here (empty by default)
+      # part :label
+      # part :icon
+
+      def initialize(**kws)
+        super(**kws)
+      end
+
+      def before_render
+        setup_component
+        super # Call super after setup
+      end
+
+      private
+
+      def setup_component
+        # TODO - Add css, html, and possibly set tag name
+      end
+    end
+  end
+end
+```
+
+Where:
+- `{ModuleName}` is the capitalized version of `component_group` (e.g., `DataInput`)
+- `{ClassName}` is the capitalized version of `component_name` (e.g., `TextInput`)
+
+### 3. Create Component Template File
+
+**File path**: `app/components/daisy/{component_group}/{component_name}_component.html.haml`
+
+**Content template**:
+
+```haml
+= part(:component) do
+  -# Basic component structure
+  {component_name}
+```
+
+### 4. Create Component Test File
+
+**File path**: `spec/components/daisy/{component_group}/{component_name}_component_spec.rb`
+
+**Content template**:
+
+```ruby
+RSpec.describe Daisy::{ModuleName}::{ClassName}Component, type: :component do
+  it "renders basic component" do
+    render_inline(described_class.new)
+    expect(page).to have_css(".{component_name}")
+  end
+end
+```
+
+Where:
+- `{ModuleName}` is the capitalized version of `component_group` (e.g., `DataInput`)
+- `{ClassName}` is the capitalized version of `component_name` (e.g., `TextInput`)
+
+### 5. Create Example File
+
+**File path**: `docs/demo/app/views/examples/daisy/{component_group}/{plural_component_name}.html.haml`
+
+Where:
+- `{plural_component_name}` is the pluralized component name (e.g., if component_name is "button", use "buttons"; if it's "entry", use "entries")
+
+**IMPORTANT RULES**:
+- MUST add a doc_title section with TODO text
+- MUST add a single doc_example section
+- MUST follow conventions shown in template below
+
+**Content template**:
+
+```haml
+= doc_title(title: "{ComponentTitle}", comp: @comp) do |title|
+  :markdown
+    TODO: Add description of the {component_name} component
+
+
+= doc_example(title: "Basic Usage", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      TODO: Add description of basic {component_name} usage
+
+  = daisy_{component_name}
+```
+
+Where:
+- `{ComponentTitle}` is the title-cased version of the component name (e.g., "Text Input")
+- `{component_name}` is the snake_case component name
+
+**After Creation**:
+
+Run the following command to restart the demo app and see the new example file:
+
+```bash
+make demo-restart
+```
+
+### 6. Register Component Helper
+
+**File path**: `lib/loco_motion/helpers.rb`
+
+Add the component to the `COMPONENTS` hash in `helpers.rb`. Find the appropriate section based on the component group and add a new entry.
+
+**Example entry to add**:
+
+```ruby
+"Daisy::{ModuleName}::{ClassName}Component" => { names: "{component_name}", group: "{GroupDisplay}", title: "{PluralTitle}", example: "{plural_component_name}" },
+```
+
+Where:
+- `{ModuleName}` is the capitalized version of `component_group` (e.g., `DataInput`)
+- `{ClassName}` is the capitalized version of `component_name` (e.g., `TextInput`)
+- `{GroupDisplay}` is the human-readable group name (e.g., `Data Input`)
+- `{PluralTitle}` is the pluralized title for the component (e.g., `Text Inputs`)
+- `{plural_component_name}` is the pluralized component name for example file (e.g., `text_inputs`)
+
+## Example Usage
+
+This is how the workflow should be used:
+
+1. Ask for component name and group
+2. Create the minimum stub files following the templates above
+3. Inform the user of the files created and what they can do next
+
+### Sample Output
+
+When you use this workflow to create a component, report back with a structure like:
+
+```
+I've created the following stub files for the new {ComponentName} component:
+
+1. Component class: `app/components/daisy/{component_group}/{component_name}_component.rb`
+2. Component template: `app/components/daisy/{component_group}/{component_name}_component.html.haml`
+3. Component spec: `spec/components/daisy/{component_group}/{component_name}_component_spec.rb`
+4. Example file: `docs/demo/app/views/examples/daisy/{component_group}/{plural_component_name}.html.haml`
+5. Added the component registration to: `lib/loco_motion/helpers.rb`
+
+I've also restarted the demo app to make the new component available.
+
+These files contain minimal implementations to get started. You can now:
+
+- Add parts and slots to the component class
+- Implement the component template
+- Write comprehensive tests
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ Read on for specific changes across the entire project! :tada:
 - feat(Toggle): Enable start/end/floating label functionality
 - feat(Checkbox): Enable start/end label functionality
 - feat(Filter): Add Filter component for creating selection interfaces with toggle functionality ([Fixes #33](https://github.com/profoundry-us/loco_motion/issues/33))
+- feat(Cally): Add new Daisy Cally and CallyInput components with date picker functionality
+- feat(Select): Add support for array and hash options in select component
+- feat(Select): Add floating label support for select inputs
+- feat(Labelable): Enhance labelable component behavior for better form handling
 
 ### Changed / Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Read on for specific changes across the entire project! :tada:
 - fix(Modal): Remove unnecessary `:dialog` part from component definition ([Fixes #46](https://github.com/profoundry-us/loco_motion/issues/46))
 - fix(Navbar): Improved implementation and styling
 - refactor(DocExample): Renamed from `ExampleWrapper` for better semantics and improved code organization
+- fix(Fieldset): Fix issue with fieldset textarea rendering
 
 #### Demo / Docs Changes
 
@@ -150,6 +151,13 @@ Read on for specific changes across the entire project! :tada:
 - fix: Header Theme Switcher was using the wrong button size
 - feat: Add soft, outline, and dash style examples to Alert, Badge, and Button examples ([Fixes #36](https://github.com/profoundry-us/loco_motion/issues/36))
 - feat: Updated component documentation to use `@loco_example` tag for better organization
+- add(DocNote): Add new error modifier to doc_note component for improved documentation
+- fix: Fix issue with figures not showing captions
+- fix: Fix typo in select docs
+- fix: Add check in set_loco_parent_patch to ensure we catch nil references
+- fix: Use shorthand floating_placeholder for label examples
+- add: Add todos about better API doc buttons
+- fix: Fix bug in boxed countdown example
 
 ## [0.4.0] - 2025-03-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ Read on for specific changes across the entire project! :tada:
 
 - **Breaking:** Upgrade from TailwindCSS 3.x to 4.x and DaisyUI 4.x to 5.x ([PR #42](https://github.com/profoundry-us/loco_motion/pull/42))
 - **Breaking:** Update existing components for DaisyUI 5 compatibility ([PR #28](https://github.com/profoundry-us/loco_motion/pull/28))
-- **Breaking:** All inputs now have a border by default, use `input-ghost` (or `*-input-ghost`) to remove (see [DaisyUI Upgrade Guide](https://daisyui.com/docs/upgrade))
+- **Breaking:** All inputs now have a border by default, use `input-ghost` (or
+  `*-input-ghost`) to remove (see [DaisyUI Upgrade Guide](https://daisyui.com/docs/upgrade))
 - **Breaking:** Migrated BottomNav component to Dock component to match DaisyUI 5 changes ([Fixes #40](https://github.com/profoundry-us/loco_motion/issues/40)):
   - `BottomNavComponent` → `DockComponent`
   - Helper method `daisy_bottom_nav` → `daisy_dock`
@@ -69,6 +70,8 @@ Read on for specific changes across the entire project! :tada:
 - refactor: Implement Concern Lifecycle Hooks in `BaseComponent` for consistent initialization and setup ([PR #54](https://github.com/profoundry-us/loco_motion/pull/54))
 - refactor: Move component concerns to lib directory for better organization
 - test: Add comprehensive tests for IconableComponent, LinkableComponent, and TippableComponent
+- refactor: The Loco parent is now set automatically in slots (`slot_loco_parent_patch.rb`) and you can
+  pass the `loco_parent` option when creating a new component to set it manually when needed
 
 #### Component Changes
 

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ demo-console:
 .PHONY: demo-restart
 demo-restart:
 	touch docs/demo/tmp/restart.txt
+	terminal-notifier -message "Loco Demo App restarting..." || true
 
 # Open a shell to your demo container
 .PHONY: demo-shell

--- a/README.md
+++ b/README.md
@@ -990,6 +990,8 @@ the GitHub Discussions feature and let us know!
 - [ ] Add title and description content_for blocks to all examples for SEO purposes
 - [ ] Update to Tailwind 4 and DaisyUI 5
 - [ ] Rename the `Dockerfile` to `Dockerfile.loco` to be more concise
+- [x] See if we can remove all of the `set_loco_parent` calls in favor of using
+      the `lib/loco_motion/patches/view_component/slot_loco_parent_patch.rb`
 
 [1]: https://loco-motion.profoundry.us/
 [2]: https://loco-motion-demo-staging.profoundry.us/

--- a/README.md
+++ b/README.md
@@ -992,6 +992,8 @@ the GitHub Discussions feature and let us know!
 - [ ] Rename the `Dockerfile` to `Dockerfile.loco` to be more concise
 - [x] See if we can remove all of the `set_loco_parent` calls in favor of using
       the `lib/loco_motion/patches/view_component/slot_loco_parent_patch.rb`
+- [ ] Make the tooltips documentation button a component and use it for the
+      Labelable concern docs too
 
 [1]: https://loco-motion.profoundry.us/
 [2]: https://loco-motion-demo-staging.profoundry.us/

--- a/app/components/daisy/actions/dropdown_component.html.haml
+++ b/app/components/daisy/actions/dropdown_component.html.haml
@@ -1,6 +1,8 @@
 = part(:component) do
   - if activator?
     = activator
+  - elsif input?
+    = input
   - else
     = button
 

--- a/app/components/daisy/actions/dropdown_component.html.haml
+++ b/app/components/daisy/actions/dropdown_component.html.haml
@@ -1,8 +1,6 @@
 = part(:component) do
   - if activator?
     = activator
-  - elsif input?
-    = input
   - else
     = button
 

--- a/app/components/daisy/actions/dropdown_component.rb
+++ b/app/components/daisy/actions/dropdown_component.rb
@@ -16,6 +16,8 @@
 #   and is styled automatically.
 # @slot activator A custom (i.e. non-button) activator for the dropdown.
 #   Automatically adds the `role="button"` and `tabindex="0"` attributes.
+# @slot input A text input field that can be included in the dropdown menu, useful
+#   for search functionality or filtering dropdown options.
 # @slot item+ The items in the dropdown. Each item will be styled consistently
 #   with proper spacing and hover states.
 #
@@ -54,6 +56,11 @@
 #         = heroicon_tag "arrow-right-on-rectangle"
 #         Logout
 #
+# @loco_example With Calendar Input
+#   = daisy_dropdown do |dropdown|
+#     - dropdown.with_input(id: "some_date", placeholder: "Birth date...", css: "my-2 w-full")
+#     = daisy_cally(input: "#some_date")
+#
 class Daisy::Actions::DropdownComponent < LocoMotion::BaseComponent
 
   include ViewComponent::SlotableDefault
@@ -62,6 +69,7 @@ class Daisy::Actions::DropdownComponent < LocoMotion::BaseComponent
 
   renders_one :activator, LocoMotion::BasicComponent.build(html: { role: "button", tabindex: 0 })
   renders_one :button, Daisy::Actions::ButtonComponent
+  renders_one :input, Daisy::DataInput::TextInputComponent
   renders_many :items, LocoMotion::BasicComponent.build(tag_name: :li, css: "menu-item")
 
   #

--- a/app/components/daisy/actions/dropdown_component.rb
+++ b/app/components/daisy/actions/dropdown_component.rb
@@ -16,8 +16,6 @@
 #   and is styled automatically.
 # @slot activator A custom (i.e. non-button) activator for the dropdown.
 #   Automatically adds the `role="button"` and `tabindex="0"` attributes.
-# @slot input A text input field that can be included in the dropdown menu, useful
-#   for search functionality or filtering dropdown options.
 # @slot item+ The items in the dropdown. Each item will be styled consistently
 #   with proper spacing and hover states.
 #
@@ -56,11 +54,6 @@
 #         = heroicon_tag "arrow-right-on-rectangle"
 #         Logout
 #
-# @loco_example With Calendar Input
-#   = daisy_dropdown do |dropdown|
-#     - dropdown.with_input(id: "some_date", placeholder: "Birth date...", css: "my-2 w-full")
-#     = daisy_cally(input: "#some_date")
-#
 class Daisy::Actions::DropdownComponent < LocoMotion::BaseComponent
 
   include ViewComponent::SlotableDefault
@@ -69,7 +62,6 @@ class Daisy::Actions::DropdownComponent < LocoMotion::BaseComponent
 
   renders_one :activator, LocoMotion::BasicComponent.build(html: { role: "button", tabindex: 0 })
   renders_one :button, Daisy::Actions::ButtonComponent
-  renders_one :input, Daisy::DataInput::TextInputComponent
   renders_many :items, LocoMotion::BasicComponent.build(tag_name: :li, css: "menu-item")
 
   #

--- a/app/components/daisy/data_display/accordion_component.html.haml
+++ b/app/components/daisy/data_display/accordion_component.html.haml
@@ -1,4 +1,3 @@
 = part(:component) do
   - sections.each do |section|
-    - section.set_loco_parent(component_ref)
     = section

--- a/app/components/daisy/data_display/accordion_component.rb
+++ b/app/components/daisy/data_display/accordion_component.rb
@@ -93,7 +93,7 @@ class Daisy::DataDisplay::AccordionComponent < LocoMotion::BaseComponent
 
     def setup_component
       # Reset the name to the config option or the parent name if available
-      @name = config_option(:name, loco_parent&.name)
+      @name = config_option(:name, loco_parent.name)
 
       add_css(:component, "collapse")
       add_css(:component, "collapse-arrow") if loco_parent.config.modifiers.include?(:arrow)
@@ -159,7 +159,7 @@ class Daisy::DataDisplay::AccordionComponent < LocoMotion::BaseComponent
 
     @name = config_option(:name, "accordion-#{SecureRandom.uuid}")
   end
-  
+
   def before_render
     super
   end

--- a/app/components/daisy/data_display/figure_component.rb
+++ b/app/components/daisy/data_display/figure_component.rb
@@ -40,10 +40,11 @@ class Daisy::DataDisplay::FigureComponent < LocoMotion::BaseComponent
   def call
     part(:component) do
       if @src
-        part(:image)
-      else
-        content
+        concat(part(:image))
       end
+
+      # Always show the content
+      concat(content)
     end
   end
 end

--- a/app/components/daisy/data_input/cally_component.html.haml
+++ b/app/components/daisy/data_input/cally_component.html.haml
@@ -1,0 +1,14 @@
+= part(:component) do
+  = previous_icon if previous_icon?
+  = next_icon if next_icon?
+
+  - if @month_count
+    = part(:months) do
+      - @month_count.times do |index|
+        = render(MonthComponent.new(**month_options(index)))
+
+  - elsif months?
+    = months
+
+  - else
+    = content

--- a/app/components/daisy/data_input/cally_component.rb
+++ b/app/components/daisy/data_input/cally_component.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Daisy
+  module DataInput
+    class CallyComponent < LocoMotion::BaseComponent
+      include ViewComponent::SlotableDefault
+
+      class PreviousIcon < Hero::IconComponent
+        def before_render
+          super
+
+          add_html(:component, { slot: "previous" })
+        end
+      end
+
+      class NextIcon < Hero::IconComponent
+        def before_render
+          super
+
+          add_html(:component, { slot: "next" })
+        end
+      end
+
+      class MonthComponent < LocoMotion::BaseComponent
+        def initialize(**kws)
+          super
+
+          @offset = config_option(:offset)
+        end
+
+        def before_render
+          super
+
+          set_tag_name(:component, "calendar-month")
+          add_html(:component, { offset: @offset }) if @offset
+        end
+
+        def call
+          part(:component)
+        end
+      end
+
+      define_modifiers :range
+
+      renders_one :previous_icon, PreviousIcon
+      renders_one :next_icon, NextIcon
+      renders_many :months, MonthComponent
+
+      define_parts :months
+
+      def initialize(**kws)
+        super
+
+        # If we don't have any modifiers, assume we want a single month for a date select
+        @month_count = config_option(:months, modifiers.blank? ? 1 : nil)
+        @change = config_option(:change)
+        @update = config_option(:update)
+
+        @id = config_option(:id)
+        @value = config_option(:value)
+        @min = config_option(:min)
+        @max = config_option(:max)
+        @today = config_option(:today)
+      end
+
+      def before_render
+        super
+
+        if modifiers.include?(:range)
+          set_tag_name(:component, "calendar-range")
+        else
+          set_tag_name(:component, "calendar-date")
+        end
+
+        add_css(:component, "cally")
+        add_html(:component, { months: @month_count }) if @month_count
+
+        add_html(:component, {
+          id: @id,
+          value: @value,
+          min: @min,
+          max: @max,
+          today: @today
+        })
+
+        if @change
+          add_html(:component, { onchange: "document.getElementById('#{@change}').value = this.value" })
+        end
+
+        if @update
+          add_html(:component, { onchange: "document.getElementById('#{@update}').innerHTML = this.value" })
+        end
+      end
+
+      def month_options(index)
+        options = {}
+
+        options[:offset] = index if index > 0
+
+        options
+      end
+
+      def default_previous_icon
+        PreviousIcon.new(icon: "chevron-left")
+      end
+
+      def default_next_icon
+        NextIcon.new(icon: "chevron-right")
+      end
+    end
+  end
+end

--- a/app/components/daisy/data_input/cally_component.rb
+++ b/app/components/daisy/data_input/cally_component.rb
@@ -7,7 +7,7 @@ module Daisy
     # options including the number of months to show and navigation controls.
     #
     # @part component The root calendar element that contains all other parts.
-    # @part months The container element that holds the month components.
+    # @part months The container element that holds the individual month components.
     #
     # @slot previous_icon [PreviousIcon] The icon used for navigating to the
     #   previous month. Defaults to a chevron-left icon.
@@ -93,8 +93,10 @@ module Daisy
       # configured for date range selection.  The component automatically
       # handles navigation between months and can display multiple months.
       #
-      # @param change [String] ID of an input to update with the selected date
-      # @param update [String] ID of an element to update with the selected date
+      # @param change [String] ID of an input to update with the selected date.
+      #   Mutually exclusive with `update`.
+      # @param update [String] ID of an element to update with the selected
+      #   date. Mutually exclusive with `change`.
       # @param id [String] The ID of the calendar element
       # @param value [String, Date] The currently selected date or range
       # @param min [String, Date] The minimum selectable date

--- a/app/components/daisy/data_input/cally_component.rb
+++ b/app/components/daisy/data_input/cally_component.rb
@@ -2,9 +2,40 @@
 
 module Daisy
   module DataInput
+    # The Cally component provides a customizable calendar interface for date selection.
+    # It supports both single date and date range selection, with configurable display
+    # options including the number of months to show and navigation controls.
+    #
+    # @part component - The root calendar element that contains all other parts.
+    # @part months - The container element that holds the month components.
+    #
+    # @slot previous_icon [PreviousIcon] The icon used for navigating to the
+    #   previous month. Defaults to a chevron-left icon.
+    #   @see #default_previous_icon
+    # @slot next_icon [NextIcon] The icon used for navigating to the next month.
+    #   Defaults to a chevron-right icon.
+    #   @see #default_next_icon
+    # @slot months+ [MonthComponent] The month components to display in the calendar.
+    #   Multiple months can be displayed side by side.
+    #   @see #month_options
+    #
+    # @loco_example Basic calendar with default options
+    #   = daisy_cally
+    #
+    # @loco_example Calendar with range selection enabled
+    #   = daisy_cally(:range)
+    #
+    # @loco_example Calendar showing multiple months with custom value
+    #   = daisy_cally(months: 2, value: Date.today)
+    #
+    # @loco_example Calendar with min/max date constraints
+    #   = daisy_cally(min: 1.month.ago, max: 1.month.from_now)
     class CallyComponent < LocoMotion::BaseComponent
       include ViewComponent::SlotableDefault
 
+      # A component for the previous navigation icon in the calendar header.
+      #
+      # @note This is used internally by CallyComponent
       class PreviousIcon < Hero::IconComponent
         def before_render
           super
@@ -13,6 +44,9 @@ module Daisy
         end
       end
 
+      # A component for the next navigation icon in the calendar header.
+      #
+      # @note This is used internally by CallyComponent
       class NextIcon < Hero::IconComponent
         def before_render
           super
@@ -21,7 +55,11 @@ module Daisy
         end
       end
 
+      # A component representing a single month in the calendar.
+      #
+      # @note This is used internally by CallyComponent
       class MonthComponent < LocoMotion::BaseComponent
+        # @param offset [Integer, nil] The offset of this month from the start date
         def initialize(**kws)
           super
 
@@ -48,6 +86,22 @@ module Daisy
 
       define_parts :months
 
+      # Initializes a new CallyComponent.
+      #
+      # The Cally component provides a customizable calendar interface for date
+      # selection.  It supports single date selection by default and can be
+      # configured for date range selection.  The component automatically
+      # handles navigation between months and can display multiple months.
+      #
+      # @param change [String, nil] ID of an input to update with the selected date
+      # @param update [String, nil] ID of an element to update with the selected date
+      # @param id [String, nil] The ID of the calendar element
+      # @param value [String, Date, nil] The currently selected date or range
+      # @param min [String, Date, nil] The minimum selectable date
+      # @param max [String, Date, nil] The maximum selectable date
+      # @param today [String, Date, nil] The date to consider as 'today'
+      # @param months [Integer, nil] Number of months to display (default: 1)
+      # @option options [Boolean] :range Whether to enable range selection (default: false)
       def initialize(**kws)
         super
 
@@ -92,6 +146,10 @@ module Daisy
         end
       end
 
+      # Generates options for a month component at the given index.
+      #
+      # @param index [Integer] The 0-based index of the month
+      # @return [Hash] Options hash for the month component
       def month_options(index)
         options = {}
 
@@ -100,10 +158,16 @@ module Daisy
         options
       end
 
+      # Provides a default previous icon if none is specified.
+      #
+      # @return [PreviousIcon] A chevron-left icon
       def default_previous_icon
         PreviousIcon.new(icon: "chevron-left")
       end
 
+      # Provides a default next icon if none is specified.
+      #
+      # @return [NextIcon] A chevron-right icon
       def default_next_icon
         NextIcon.new(icon: "chevron-right")
       end

--- a/app/components/daisy/data_input/cally_component.rb
+++ b/app/components/daisy/data_input/cally_component.rb
@@ -6,8 +6,8 @@ module Daisy
     # It supports both single date and date range selection, with configurable display
     # options including the number of months to show and navigation controls.
     #
-    # @part component - The root calendar element that contains all other parts.
-    # @part months - The container element that holds the month components.
+    # @part component The root calendar element that contains all other parts.
+    # @part months The container element that holds the month components.
     #
     # @slot previous_icon [PreviousIcon] The icon used for navigating to the
     #   previous month. Defaults to a chevron-left icon.
@@ -23,7 +23,7 @@ module Daisy
     #   = daisy_cally
     #
     # @loco_example Calendar with range selection enabled
-    #   = daisy_cally(:range)
+    #   = daisy_cally(modifier: :range)
     #
     # @loco_example Calendar showing multiple months with custom value
     #   = daisy_cally(months: 2, value: Date.today)
@@ -93,15 +93,14 @@ module Daisy
       # configured for date range selection.  The component automatically
       # handles navigation between months and can display multiple months.
       #
-      # @param change [String, nil] ID of an input to update with the selected date
-      # @param update [String, nil] ID of an element to update with the selected date
-      # @param id [String, nil] The ID of the calendar element
-      # @param value [String, Date, nil] The currently selected date or range
-      # @param min [String, Date, nil] The minimum selectable date
-      # @param max [String, Date, nil] The maximum selectable date
-      # @param today [String, Date, nil] The date to consider as 'today'
-      # @param months [Integer, nil] Number of months to display (default: 1)
-      # @option options [Boolean] :range Whether to enable range selection (default: false)
+      # @param change [String] ID of an input to update with the selected date
+      # @param update [String] ID of an element to update with the selected date
+      # @param id [String] The ID of the calendar element
+      # @param value [String, Date] The currently selected date or range
+      # @param min [String, Date] The minimum selectable date
+      # @param max [String, Date] The maximum selectable date
+      # @param today [String, Date] The date to consider as 'today'
+      # @param months [Integer] Number of months to display (default: 1)
       def initialize(**kws)
         super
 
@@ -117,6 +116,11 @@ module Daisy
         @today = config_option(:today)
       end
 
+      # Configures the calendar component before rendering.
+      #
+      # Sets up the appropriate tag name based on whether range selection is
+      # enabled, adds CSS classes, and configures HTML attributes for the
+      # calendar component.
       def before_render
         super
 

--- a/app/components/daisy/data_input/cally_input_component.html.haml
+++ b/app/components/daisy/data_input/cally_input_component.html.haml
@@ -1,0 +1,5 @@
+= part(:component) do
+  = input
+
+  = part(:popover) do
+    = calendar

--- a/app/components/daisy/data_input/cally_input_component.rb
+++ b/app/components/daisy/data_input/cally_input_component.rb
@@ -1,0 +1,164 @@
+module Daisy
+  module DataInput
+    # A specialized input component that combines a text input with a calendar picker.
+    # The calendar appears in a popover when the input is focused or clicked.
+    #
+    # @part popover The container for the calendar popover.
+    #
+    # @slot input The text input component.
+    # @slot calendar The calendar component that appears in the popover.
+    #
+    # @option id [String] A unique identifier for the input (default: auto-generated).
+    # @option name [String] The name attribute for the input field.
+    # @option value [Date, String] The initial value of the input (default: `nil`).
+    # @option css [String] Additional CSS classes for the component.
+    #
+    # @loco_example Basic Usage
+    #   = daisy_cally_input(name: "event_date", value: Date.today)
+    #
+    # @loco_example With custom calendar and input components
+    #   = daisy_cally_input(name: "event_date") do |c|
+    #     = c.with_calendar(css: "custom-calendar")
+    #     = c.with_input(css: "custom-input")
+    class CallyInputComponent < LocoMotion::BaseComponent
+      # A specialized text input component for the CallyInput that handles popover targeting
+      # and data attributes needed for the Stimulus controller.
+      class CallyTextInputComponent < Daisy::DataInput::TextInputComponent
+        # Sets up the HTML attributes needed for the text input before rendering.
+        # Configures the popover target, ID, name, and data attributes required
+        # for the Stimulus controller to function properly.
+        #
+        # @return [void]
+        def before_render
+          parent_config = loco_parent.config
+
+          @start = config_option(:start, parent_config.options[:start])
+          @end = config_option(:end, parent_config.options[:end])
+          @floating = config_option(:floating, parent_config.options[:floating])
+          @placeholder = config_option(:placeholder, parent_config.options[:placeholder])
+          @floating_placeholder = config_option(:floating_placeholder, parent_config.options[:floating_placeholder])
+
+          super
+
+          add_html(:component, {
+            popovertarget: loco_parent.popover_id,
+            id: @id || loco_parent.input_id,
+            name: @name || loco_parent.name,
+            value: @value || parent_config.options[:value],
+            placeholder: @placeholder,
+            style: "anchor-name:--#{loco_parent.anchor}",
+            data: {
+              "cally-input-target": "input"
+            }
+          })
+        end
+
+        def call
+          render_parent_to_string
+        end
+      end
+
+      # A specialized calendar component for the CallyInput that handles the calendar
+      # display and interaction within a popover.
+      class CallyCalendarComponent < Daisy::DataInput::CallyComponent
+        # Sets up the HTML attributes needed for the calendar before rendering.
+        # Configures the ID, value, and data attributes required for the Stimulus controller.
+        #
+        # @return [void]
+        def before_render
+          super
+
+          add_html(:component, {
+            id: @id || loco_parent.calendar_id,
+            value: @value || loco_parent.value,
+            data: {
+              "cally-input-target": "calendar"
+            }
+          })
+        end
+
+        def call
+          render_parent_to_string
+        end
+      end
+
+      include ViewComponent::SlotableDefault
+      include LocoMotion::Concerns::LabelableComponent
+
+      define_parts :popover
+
+      renders_one :calendar, CallyCalendarComponent
+      renders_one :input, CallyTextInputComponent
+
+      attr_reader :id, :name, :value, :calendar_id, :input_id, :popover_id, :anchor
+
+      # Initializes a new CallyInputComponent.
+      #
+      # @param [Hash] kws The options hash
+      # @option kws [String] :id A unique identifier for the input (default: auto-generated)
+      # @option kws [String] :name The name attribute for the input field
+      # @option kws [Date, String] :value The initial value of the input (default: nil)
+      # @option kws [String] :css Additional CSS classes for the component
+      def initialize(**kws)
+        super(**kws)
+
+        @id = config_option(:id, SecureRandom.uuid)
+        @name = config_option(:name)
+        @value = config_option(:value)
+
+        # Input ID should match our ID
+        @input_id = @id
+
+        # Other IDs / options are generated
+        @calendar_id = "#{@id}-calendar"
+        @popover_id = "#{@id}-popover"
+        @anchor = "#{@id}-anchor"
+      end
+
+      # Sets up the component before rendering.
+      # Calls the parent's before_render and then runs the component setup.
+      #
+      # @return [void]
+      def before_render
+        super
+
+        setup_component
+      end
+
+      # Provides a default calendar component instance.
+      # This is used when no custom calendar component is provided.
+      #
+      # @return [CallyCalendarComponent] A new instance of the default calendar component
+      def default_calendar
+         CallyCalendarComponent.new
+      end
+
+      # Provides a default input component instance.
+      # This is used when no custom input component is provided.
+      #
+      # @return [CallyTextInputComponent] A new instance of the default input component
+      def default_input
+        CallyTextInputComponent.new
+      end
+
+      private
+
+      # Sets up the component's HTML structure and attributes.
+      # Configures the Stimulus controller and popover attributes.
+      #
+      # @return [void]
+      # @private
+      def setup_component
+        # Ensure we attach the Stimulus controller
+        add_stimulus_controller(:component, "cally-input")
+
+        # Add relevant popover part HTML
+        add_html(:popover, { id: @popover_id, popover: "auto", style: "position-anchor:--#{@anchor}" })
+        add_html(:popover, { data: { "cally-input-target": "popover" } })
+
+        # Note that we NEED the dropdown class so that the anchor positioning works properly
+        add_css(:popover, "where:dropdown where:bg-base-100 where:rounded where:shadow-lg")
+      end
+    end
+  end
+end

--- a/app/components/daisy/data_input/cally_input_component.rb
+++ b/app/components/daisy/data_input/cally_input_component.rb
@@ -1,17 +1,13 @@
 module Daisy
   module DataInput
-    # A specialized input component that combines a text input with a calendar picker.
-    # The calendar appears in a popover when the input is focused or clicked.
+    # A specialized input component that combines a text input with a calendar
+    # picker. The calendar appears in a popover when the input is focused or
+    # clicked.
     #
     # @part popover The container for the calendar popover.
     #
     # @slot input The text input component.
     # @slot calendar The calendar component that appears in the popover.
-    #
-    # @option id [String] A unique identifier for the input (default: auto-generated).
-    # @option name [String] The name attribute for the input field.
-    # @option value [Date, String] The initial value of the input (default: `nil`).
-    # @option css [String] Additional CSS classes for the component.
     #
     # @loco_example Basic Usage
     #   = daisy_cally_input(name: "event_date", value: Date.today)
@@ -21,22 +17,25 @@ module Daisy
     #     = c.with_calendar(css: "custom-calendar")
     #     = c.with_input(css: "custom-input")
     class CallyInputComponent < LocoMotion::BaseComponent
-      # A specialized text input component for the CallyInput that handles popover targeting
-      # and data attributes needed for the Stimulus controller.
+      # A specialized text input component for the CallyInput that handles
+      # popover targeting and data attributes needed for the Stimulus
+      # controller.
       class CallyTextInputComponent < Daisy::DataInput::TextInputComponent
-        # Sets up the HTML attributes needed for the text input before rendering.
-        # Configures the popover target, ID, name, and data attributes required
-        # for the Stimulus controller to function properly.
+        # Sets up the HTML attributes needed for the text input before
+        # rendering.  Configures the popover target, ID, name, and data
+        # attributes required for the Stimulus controller to function properly.
         #
         # @return [void]
         def before_render
           parent_config = loco_parent.config
 
+          # Since we're pulling options from the parent, we have to do a little
+          # more work to ensure we set it up correctly.
           @start = config_option(:start, parent_config.options[:start])
           @end = config_option(:end, parent_config.options[:end])
-          @floating = config_option(:floating, parent_config.options[:floating])
-          @placeholder = config_option(:placeholder, parent_config.options[:placeholder])
           @floating_placeholder = config_option(:floating_placeholder, parent_config.options[:floating_placeholder])
+          @floating = config_option(:floating, parent_config.options[:floating] || @floating_placeholder)
+          @placeholder = config_option(:placeholder, parent_config.options[:placeholder] || @floating_placeholder)
 
           super
 
@@ -90,7 +89,7 @@ module Daisy
       renders_one :calendar, CallyCalendarComponent
       renders_one :input, CallyTextInputComponent
 
-      attr_reader :id, :name, :value, :calendar_id, :input_id, :popover_id, :anchor
+      attr_reader :id, :name, :value, :calendar_id, :input_id, :popover_id, :anchor, :auto_scroll_padding
 
       # Initializes a new CallyInputComponent.
       #
@@ -98,6 +97,7 @@ module Daisy
       # @option kws [String] :id A unique identifier for the input (default: auto-generated)
       # @option kws [String] :name The name attribute for the input field
       # @option kws [Date, String] :value The initial value of the input (default: nil)
+      # @option kws [Integer] :auto_scroll_padding The padding to use when scrolling the calendar into view (default: 100)
       # @option kws [String] :css Additional CSS classes for the component
       def initialize(**kws)
         super(**kws)
@@ -105,6 +105,7 @@ module Daisy
         @id = config_option(:id, SecureRandom.uuid)
         @name = config_option(:name)
         @value = config_option(:value)
+        @auto_scroll_padding = config_option(:auto_scroll_padding, 100)
 
         # Input ID should match our ID
         @input_id = @id
@@ -154,7 +155,7 @@ module Daisy
 
         # Add relevant popover part HTML
         add_html(:popover, { id: @popover_id, popover: "auto", style: "position-anchor:--#{@anchor}" })
-        add_html(:popover, { data: { "cally-input-target": "popover" } })
+        add_html(:popover, { data: { "cally-input-target": "popover", "auto-scroll-padding": @auto_scroll_padding } })
 
         # Note that we NEED the dropdown class so that the anchor positioning works properly
         add_css(:popover, "where:dropdown where:bg-base-100 where:rounded where:shadow-lg")

--- a/app/components/daisy/data_input/cally_input_controller.js
+++ b/app/components/daisy/data_input/cally_input_controller.js
@@ -1,0 +1,197 @@
+import { Controller } from "@hotwired/stimulus"
+
+/**
+ * Controller for handling calendar input interactions.
+ * Manages the popover calendar UI and synchronization between input and calendar elements.
+ */
+export default class extends Controller {
+  static targets = ["calendar", "input", "popover"]
+
+  /**
+   * Initializes the controller and sets up event listeners.
+   * Binds all methods to ensure proper 'this' context.
+   *
+   * @returns {void}
+   */
+  connect() {
+
+    // Save the bound functions so we can remove them later
+    this.boundUpdateInput = this.updateInput.bind(this)
+    this.boundUpdateCalendar = this.updateCalendar.bind(this)
+    this.boundOpenCalendar = this.openCalendar.bind(this)
+    this.boundCloseCalendar = this.closeCalendar.bind(this)
+    this.boundHandleKeydown = this.handleKeydown.bind(this)
+    this.boundHandleToggle = this.handleToggle.bind(this)
+
+    // Bind all of our functions
+    this.calendarTarget.addEventListener("change", this.boundUpdateInput)
+    this.calendarTarget.addEventListener("blur", this.boundCloseCalendar)
+
+    this.inputTarget.addEventListener("change", this.boundUpdateCalendar)
+    this.inputTarget.addEventListener("keyup", this.boundUpdateCalendar)
+    this.inputTarget.addEventListener("click", this.boundOpenCalendar)
+    this.inputTarget.addEventListener("keydown", this.boundHandleKeydown)
+
+    this.popoverTarget.addEventListener("toggle", this.boundHandleToggle)
+  }
+
+  /**
+   * Cleans up event listeners when the controller is disconnected.
+   * Prevents memory leaks by removing all bound event handlers.
+   *
+   * @returns {void}
+   */
+  disconnect() {
+    this.calendarTarget.removeEventListener("change", this.boundUpdateInput)
+    this.calendarTarget.removeEventListener("blur", this.boundCloseCalendar)
+
+    this.inputTarget.removeEventListener("change", this.boundUpdateCalendar)
+    this.inputTarget.removeEventListener("keyup", this.boundUpdateCalendar)
+    this.inputTarget.removeEventListener("keydown", this.boundHandleKeydown)
+    this.inputTarget.removeEventListener("click", this.boundOpenCalendar)
+  }
+
+  /**
+   * Opens the calendar popover.
+   *
+   * @returns {void}
+   */
+  openCalendar() {
+    // Open the popover
+    this.popoverTarget.togglePopover(true)
+  }
+
+  /**
+   * Closes the calendar popover if the blur event is not related to calendar elements.
+   *
+   * @param {FocusEvent} event - The blur event object.
+   *
+   * @returns {void}
+   */
+  closeCalendar(event) {
+    // Don't close if we're still in the calendar elements
+    if (event.relatedTarget && this.calendarTarget.contains(event.relatedTarget)) {
+      return
+    }
+
+    this.popoverTarget.togglePopover(false)
+  }
+
+  /**
+   * Handles the popover toggle event.
+   * - When opening: Sets a space in empty inputs to prevent floating label flicker
+   * - When closing: Clears the single-space input to ensure proper floating label behavior
+   *
+   * @param {Event} event - The toggle event object with newState property
+   * @returns {void}
+   */
+  handleToggle(event) {
+    if (this.inputTarget.parentElement.classList.contains("floating-label")) {
+      const ZERO_WIDTH_SPACE = '\u200B';
+      if (event.newState === 'open') {
+        // Set the input to a zero-width space if it is empty to prevent a floating label
+        // flicker when the calendar loses focus while setting the date
+        if (this.inputTarget.value == null || this.inputTarget.value === '') {
+          this.inputTarget.value = ZERO_WIDTH_SPACE;
+        }
+      } else if (event.newState === 'closed') {
+        // Unset the zero-width space input on close so the floating label works again
+        if (this.inputTarget.value === ZERO_WIDTH_SPACE) {
+          this.inputTarget.value = null;
+        }
+      }
+    }
+  }
+
+  /**
+   * Updates the input value from the calendar and closes the popover.
+   * Synchronizes the input field with the selected date.
+   *
+   * @returns {void}
+   */
+  updateInput() {
+    // Update the input value and close the popover
+    this.inputTarget.value = this.calendarTarget.value
+    this.popoverTarget.togglePopover(false)
+  }
+
+  /**
+   * Handles keyboard navigation for the calendar input.
+   * - SPACE: Toggles the popover
+   * - ENTER: Closes an open popover
+   * - ARROW DOWN / ARROW UP: Opens the popover and focuses the calendar
+   *
+   * @param {KeyboardEvent} event - The keyboard event object.
+   *
+   * @returns {void}
+   */
+  handleKeydown(event) {
+    const hasModifierKeys = event.ctrlKey || event.shiftKey || event.altKey || event.metaKey;
+    const isOpen = this.popoverTarget.matches(':popover-open')
+
+    //
+    // SPACE - Toggles the popover.
+    //
+    if (event.key === ' ' || event.code === 'Space') {
+      event.preventDefault()
+
+      this.popoverTarget.togglePopover()
+    }
+
+    //
+    // ENTER - Closes an open popover
+    //
+    else if (isOpen && (event.key === 'Enter' || event.code === 'Enter')) {
+      // Stop the enter key from triggering the form submission
+      event.preventDefault();
+
+      this.popoverTarget.togglePopover(false)
+    }
+
+    //
+    // ARROW DOWN / ARROW UP - Opens the popover and focuses the calendar
+    //
+    else if ((event.key === 'ArrowDown' || event.code === 'ArrowUp') && !hasModifierKeys) {
+      event.preventDefault()
+
+      // If the calendar is not already open, open it
+      if (!this.popoverTarget.matches(':popover-open')) {
+        this.popoverTarget.togglePopover(true)
+      }
+
+      // Focus the calendar element
+      this.calendarTarget.focus()
+
+      // Forward the keydown event to the calendar
+      const forwardedEvent = new KeyboardEvent('keydown', {
+        key: event.key,
+        code: event.code,
+        bubbles: true,
+        cancelable: true,
+        keyCode: event.keyCode
+      })
+
+      // Dispatch the forwarded event to the calendar
+      this.calendarTarget.dispatchEvent(forwardedEvent)
+    }
+  }
+
+  /**
+   * Updates the calendar's value based on the input field.
+   * Only updates if the input contains a valid ISO 8601 date.
+   *
+   * @returns {void}
+   */
+  updateCalendar() {
+    // Only update the calendar if we have a full / valid ISO 8601 date
+    let newDate = this.inputTarget.value
+
+    if (newDate.length !== 10 || new Date(newDate).toString() === "Invalid Date") {
+      return
+    }
+
+    // Set the calendar value and focused-date attributes
+    this.calendarTarget.value = newDate
+    this.calendarTarget.setAttribute('focused-date', newDate)
+  }
+}

--- a/app/components/daisy/data_input/filter_component.rb
+++ b/app/components/daisy/data_input/filter_component.rb
@@ -58,8 +58,8 @@ module Daisy
         #
         def before_render
           # Make sure to pull the default name from the parent
-          @name = config_option(:name, loco_parent&.name)
-          @id = config_option(:id, "#{loco_parent&.id}_#{@index}")
+          @name = config_option(:name, loco_parent.name)
+          @id = config_option(:id, "#{loco_parent.id}_#{@index}")
 
           # Call the parent setup first
           super
@@ -94,8 +94,8 @@ module Daisy
         #
         def before_render
           # Make sure to pull the default name from the parent
-          @name = config_option(:name, loco_parent&.name)
-          @id = config_option(:id, "#{loco_parent&.id}_reset")
+          @name = config_option(:name, loco_parent.name)
+          @id = config_option(:id, "#{loco_parent.id}_reset")
 
           # Call parent setup first
           super
@@ -143,15 +143,10 @@ module Daisy
         super
 
         setup_component
-        setup_reset_button if reset_button?
       end
 
       def default_reset_button
-        comp = FilterResetComponent.new(name: @name)
-
-        comp.set_loco_parent(component_ref)
-
-        comp
+        FilterResetComponent.new(name: @name)
       end
 
       #
@@ -171,6 +166,7 @@ module Daisy
           checked = @value.present? && @value.to_s == value.to_s
 
           Daisy::DataInput::FilterComponent::FilterOptionComponent.new(
+            loco_parent: component_ref,
             name: @name,
             label: label,
             value: value,
@@ -191,12 +187,10 @@ module Daisy
 
         if options?
           options.each do |option|
-            option.set_loco_parent(component_ref)
             result += render(option)
           end
         elsif standard_options.present?
           standard_options.each do |option|
-            option.set_loco_parent(component_ref)
             result += render(option)
           end
         end
@@ -212,13 +206,6 @@ module Daisy
       def setup_component
         # Add base component class
         add_css(:component, "filter")
-      end
-
-      #
-      # Sets up the reset button by ensuring it has access to the parent component.
-      #
-      def setup_reset_button
-        reset_button.set_loco_parent(component_ref)
       end
 
       #

--- a/app/components/daisy/data_input/rating_component.html.haml
+++ b/app/components/daisy/data_input/rating_component.html.haml
@@ -3,11 +3,9 @@
 
   - if items?
     - items.each do |item|
-      - item.set_loco_parent(component_ref)
       = item
   - elsif content?
     = content
   - elsif star_items.present?
     - star_items.each do |item|
-      - item.set_loco_parent(component_ref)
       = render(item)

--- a/app/components/daisy/data_input/rating_component.rb
+++ b/app/components/daisy/data_input/rating_component.rb
@@ -30,7 +30,7 @@ class Daisy::DataInput::RatingComponent < LocoMotion::BaseComponent
     #
     def before_render
       set_tag_name(:component, :input)
-      add_html(:component, { name: loco_parent&.name, type: "radio" })
+      add_html(:component, { name: loco_parent.name, type: "radio" })
     end
 
     #
@@ -120,6 +120,7 @@ class Daisy::DataInput::RatingComponent < LocoMotion::BaseComponent
   def star_items
     (1..@max).map do |rating|
       input_attrs = {
+        loco_parent: component_ref,
         css: ["where:mask where:mask-star", @inputs_css].compact.join(" "),
         html: {
           name: @name,

--- a/app/components/daisy/data_input/text_input_component.rb
+++ b/app/components/daisy/data_input/text_input_component.rb
@@ -60,7 +60,7 @@
 class Daisy::DataInput::TextInputComponent < LocoMotion::BaseComponent
   include LocoMotion::Concerns::LabelableComponent
 
-  attr_reader :name, :id, :value, :placeholder, :type, :disabled, :required, :readonly
+  attr_reader :name, :id, :value, :type, :disabled, :required, :readonly
 
   #
   # Instantiate a new TextInput component.
@@ -72,8 +72,6 @@ class Daisy::DataInput::TextInputComponent < LocoMotion::BaseComponent
   # @option kws id [String] The ID attribute for the text input.
   #
   # @option kws value [String] The initial value of the text input.
-  #
-  # @option kws placeholder [String] Placeholder text for the text input.
   #
   # @option kws type [String] The type of input (text, password, email, etc.).
   #   Defaults to "text".
@@ -93,11 +91,11 @@ class Daisy::DataInput::TextInputComponent < LocoMotion::BaseComponent
     @name = config_option(:name)
     @id = config_option(:id)
     @value = config_option(:value, nil)
-    @placeholder = config_option(:placeholder, nil)
     @type = config_option(:type, "text")
     @disabled = config_option(:disabled, false)
     @required = config_option(:required, false)
     @readonly = config_option(:readonly, false)
+    @change = config_option(:change)
   end
 
   #
@@ -138,5 +136,7 @@ class Daisy::DataInput::TextInputComponent < LocoMotion::BaseComponent
       required: @required,
       readonly: @readonly
     })
+
+    add_html(:component, { onchange: "document.getElementById('#{@change}').value = this.value" }) if @change
   end
 end

--- a/app/components/daisy/layout/drawer_component.html.haml
+++ b/app/components/daisy/layout/drawer_component.html.haml
@@ -5,5 +5,4 @@
     = content
 
   - if sidebar?
-    - sidebar.set_loco_parent(component_ref)
     = sidebar

--- a/app/components/daisy/navigation/breadcrumbs_component.html.haml
+++ b/app/components/daisy/navigation/breadcrumbs_component.html.haml
@@ -1,7 +1,6 @@
 = part(:component) do
   = part(:list_wrapper) do
     - items.each do |item|
-      - item.set_loco_parent(component_ref)
       = item
 
   = content

--- a/app/components/daisy/navigation/tabs_component.html.haml
+++ b/app/components/daisy/navigation/tabs_component.html.haml
@@ -1,4 +1,3 @@
 = part(:component) do
   - tabs.each do |tab|
-    - tab.set_loco_parent(component_ref)
     = tab

--- a/app/components/daisy/navigation/tabs_component.rb
+++ b/app/components/daisy/navigation/tabs_component.rb
@@ -122,9 +122,9 @@ class Daisy::Navigation::TabsComponent < LocoMotion::BaseComponent
 
     def before_render
       # Reset the name to the config option or the parent name if available
-      @name = config_option(:name, loco_parent&.name)
+      @name = config_option(:name, loco_parent.name)
 
-      if loco_parent&.radio?
+      if loco_parent.radio?
         setup_radio_button
       else
         setup_component
@@ -167,7 +167,7 @@ class Daisy::Navigation::TabsComponent < LocoMotion::BaseComponent
       # custom_content.to_s if custom_content?
 
       capture do
-        if loco_parent&.radio?
+        if loco_parent.radio?
           concat(part(:component))
         else
           concat(part(:component) { concat(title? ? title : @simple_title) })

--- a/app/helpers/daisy/form_builder_helper.rb
+++ b/app/helpers/daisy/form_builder_helper.rb
@@ -106,6 +106,11 @@ module Daisy
           render_daisy_component(Daisy::DataInput::TextAreaComponent, method, **options)
         end
 
+        # Add the daisy_cally_input method to FormBuilder
+        def daisy_cally_input(method, **options, &block)
+          render_daisy_component(Daisy::DataInput::CallyInputComponent, method, **options, &block)
+        end
+
         # Add the daisy_select method to FormBuilder
         def daisy_select(method, options: nil, option_groups: nil, placeholder: nil,
                            options_css: nil, options_html: {}, **args, &block)
@@ -156,7 +161,7 @@ module Daisy
 
         private
 
-        def render_daisy_component(component_class, method, **options)
+        def render_daisy_component(component_class, method, **options, &block)
           # Get the object name from the form builder
           object_name = @object_name.to_s
 
@@ -170,7 +175,7 @@ module Daisy
           options[:value] ||= object.try(method)
 
           # Render the component
-          @template.render component_class.new(**options)
+          @template.render(component_class.new(**options), &block)
         end
       end
     end

--- a/docs/demo/app/assets/stylesheets/safelist.txt
+++ b/docs/demo/app/assets/stylesheets/safelist.txt
@@ -1,1 +1,2 @@
 size-[800px]
+[&_span]:text-5xl

--- a/docs/demo/app/components/doc_code_component.rb
+++ b/docs/demo/app/components/doc_code_component.rb
@@ -25,7 +25,7 @@ class DocCodeComponent < ApplicationComponent
     part(:component) do
       part(:pre) do
         part(:code) do
-          content
+          content.strip
         end
       end
     end

--- a/docs/demo/app/components/doc_note_component.rb
+++ b/docs/demo/app/components/doc_note_component.rb
@@ -1,6 +1,6 @@
 class DocNoteComponent < ApplicationComponent
 
-  define_modifiers :note, :tip, :todo, :warning
+  define_modifiers :note, :tip, :todo, :warning, :error
 
   define_parts :icon, :content_wrapper
 
@@ -20,6 +20,7 @@ class DocNoteComponent < ApplicationComponent
     setup_tip if @config.modifiers.include?(:tip)
     setup_todo if @config.modifiers.include?(:todo)
     setup_warning if @config.modifiers.include?(:warning)
+    setup_error if @config.modifiers.include?(:error)
   end
 
   def setup_note
@@ -42,8 +43,8 @@ class DocNoteComponent < ApplicationComponent
     @default_icon = "ellipsis-horizontal-circle"
     @default_title = "Todo"
 
-    add_css(:component, "border-purple-600 bg-purple-100 text-purple-600")
-    add_css(:icon, "text-purple-600")
+    add_css(:component, "border-accent bg-accent/10")
+    add_css(:icon, "text-accent")
   end
 
   def setup_warning
@@ -54,4 +55,11 @@ class DocNoteComponent < ApplicationComponent
     add_css(:icon, "text-warning")
   end
 
+  def setup_error
+    @default_icon = "exclamation-triangle"
+    @default_title = "Error"
+
+    add_css(:component, "border-error bg-error/10")
+    add_css(:icon, "text-error")
+  end
 end

--- a/docs/demo/app/helpers/application_helper.rb
+++ b/docs/demo/app/helpers/application_helper.rb
@@ -28,4 +28,22 @@ module ApplicationHelper
   def doc_title(*args, **kws, &block)
     render(DocTitleComponent.new(*args, **kws), &block)
   end
+
+  # Creates a link to a component example page with consistent styling
+  #
+  # @param text [String] The button text
+  # @param component_class [String] The full component class name (e.g., "Daisy::DataInput::TextInputComponent")
+  # @param size [String] The button size (default: "btn-xs")
+  # @param html_options [Hash] Additional HTML options for the button
+  # @return [String] HTML for the component link button
+  def component_link(text, component_class, css: "btn-xs", **options)
+    daisy_button(
+      text,
+      css: css,
+      href: "/examples/#{component_class}",
+      right_icon: "cube",
+      right_icon_css: "size-4",
+      **options
+    )
+  end
 end

--- a/docs/demo/app/javascript/application.js
+++ b/docs/demo/app/javascript/application.js
@@ -4,3 +4,6 @@ import "./controllers"
 
 // Import Algolia search functionality
 import "./algolia_search"
+
+// Import third-party libraries we use
+import "cally"

--- a/docs/demo/app/javascript/controllers/index.js
+++ b/docs/demo/app/javascript/controllers/index.js
@@ -6,9 +6,12 @@ import { Application } from "@hotwired/stimulus"
 const application = Application.start()
 
 // Import LocoMotion controllers
-import { CountdownController, ThemeController } from "@profoundry-us/loco_motion"
+import { CountdownController, ThemeController, CallyInputController } from "@profoundry-us/loco_motion"
 application.register("countdown", CountdownController)
 application.register("theme", ThemeController)
+application.register("cally-input", CallyInputController)
+
+// Import demo app controllers
 
 import ActiveTabController from "./active_tab_controller"
 application.register("active-tab", ActiveTabController)

--- a/docs/demo/app/views/application/_navigation.html.haml
+++ b/docs/demo/app/views/application/_navigation.html.haml
@@ -15,6 +15,9 @@
     - # Iterate over all of the framework examples
     - last_framework, last_section = nil
     - LocoMotion::COMPONENTS.each do |name, config|
+      - # Skip if we have no examples
+      - next if config[:example].blank?
+
       - comp_split = name.split('::')
       - framework = comp_split.first
       - section = config[:group]

--- a/docs/demo/app/views/application/home.html.haml
+++ b/docs/demo/app/views/application/home.html.haml
@@ -77,7 +77,7 @@
       .mt-8.xl:mt-0
         .flex.flex-col.xl:flex.xl:flex-row.w-full
           = doc_code(css: "grow", code_css: "xl:pl-2 xl:pr-0 xl:rounded-r-none", language: "erb") do
-            :escaped
+            :plain
               <% # Ruby %>
 
               <% 5.times do |i| %>
@@ -89,7 +89,7 @@
               <% end %>
 
           = doc_code(css: "grow mt-8 xl:mt-0", pre_css: "xl:h-full", code_css: "xl:pl-0 xl:pr-2 xl:h-full xl:rounded-l-none") do
-            :escaped
+            :plain
               - # HAML
 
               - 5.times do |i|
@@ -109,14 +109,14 @@
     .mt-8.xl:flex.xl:space-x-8
       %div
         = doc_code(language: "ruby") do
-          :escaped
+          :plain
             # app/components/application_component.rb
             class ApplicationComponent < LocoMotion::BaseComponent
               # Add your custom / shared component logic here!
             end
 
         = doc_code(language: "haml", css: "mt-8") do
-          :escaped
+          :plain
             - # app/components/character_component.html.haml
             = part(:component) do
               = part(:head)
@@ -126,7 +126,7 @@
 
       %div.mt-8.xl:mt-0
         = doc_code(language: "ruby") do
-          :escaped
+          :plain
             # app/components/character_component.rb
             class CharacterComponent < ApplicationComponent
               define_parts :head, :body, :legs

--- a/docs/demo/app/views/examples/daisy/actions/dropdowns.html.haml
+++ b/docs/demo/app/views/examples/daisy/actions/dropdowns.html.haml
@@ -45,11 +45,11 @@
 
     = doc_note(css: "mb-8") do
       :markdown
-        You'll need to manually add the `dropdown-content` CSS class to the
+        You'll need to **manually** add the `dropdown-content` CSS class to the
         content wrapper.
 
-        We automatically add the `role="button"` and `tabindex="0"` attributes
-        to the custom activator to make it keyboard accessible.
+        We **automatically** add the `role="button"` and `tabindex="0"`
+        attributes to the custom activator to make it keyboard accessible.
 
   .flex.flex-col.items-end{ class: "max-w-[500px]" }
     = daisy_dropdown(css: "dropdown-end dropdown-hover") do |dropdown|

--- a/docs/demo/app/views/examples/daisy/data_input/calendars.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/calendars.html.haml
@@ -1,0 +1,74 @@
+= doc_title(title: "Calendars", comp: @comp) do |title|
+  :markdown
+    LocoMotion offers support for the [Cally](https://wicky.nillia.ms/cally/)
+    calendar web component styled by DaisyUI.
+
+  = doc_note(modifier: :warning) do
+    :markdown
+      You must include the Cally script tag or
+      <a target="_blank" href="https://wicky.nillia.ms/cally/#installation">node module</a>
+      in your application for this component to render and function properly.
+
+    = doc_code(language: "sh") do
+      :plain
+        npm install cally # or yarn add cally
+
+    = doc_code(language: "js") do
+      :plain
+        # application.js
+        import "cally";
+
+
+= doc_example(title: "Calendar", example_css: "flex-col", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      Calendars can be used to select a single date. Use the `update` option to
+      pass a CSS selector of a `<div>` or other element to update.
+
+      Note that this uses the `onchange` event along with `getElementById` to
+      provide a very basic change system. You may want to use Stimulus
+      controllers to handle more complex scenarios.
+
+    = doc_code(language: "js") do
+      :plain
+        { onchange: "document.getElementById('\#{@update}').innerHTML = this.value" }
+
+  = daisy_cally(update: "cally")
+
+  #cally.text-center.italic
+    Select a date...
+
+
+= doc_example(title: "Calendar with Input", example_css: "flex-col", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      You can utilize the `change` option to change the value of an HTML input
+      when a date is selected.
+
+      Similar to the `update` option, this uses `onchange` and `getElementById`,
+      but is specialized for updating an input element's `value`.
+
+    = doc_code(language: "js") do
+      :plain
+        { onchange: "document.getElementById('\#{@update}').value = this.value" }
+
+    = doc_note(modifier: :tip, css: "mb-8") do
+      %p
+        To attach a Cally calendar to an input in a popover, use the
+        = component_link("Cally Input", "Daisy::DataInput::CallyInputComponent", size: "btn-neutral")
+        component.
+
+  = daisy_input(id: "cally_input", placeholder: "Select a date...")
+  = daisy_cally(change: "cally_input")
+
+
+= doc_example(title: "Calendar Range", allow_reset: true) do |doc|
+  - doc.with_description do
+    :markdown
+      Calendars can also allow selection of a range of dates.
+
+  = daisy_card(css: "card-border bg-base-100 shadow-lg") do
+    = daisy_cally(modifier: :range, months: 2, months_css: "grid md:grid-cols-2 gap-8", update: "cally_range")
+
+    #cally_range.text-center.italic
+      Select a date range...

--- a/docs/demo/app/views/examples/daisy/data_input/calendars.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/calendars.html.haml
@@ -55,7 +55,7 @@
     = doc_note(modifier: :tip, css: "mb-8") do
       %p
         To attach a Cally calendar to an input in a popover, use the
-        = component_link("Cally Input", "Daisy::DataInput::CallyInputComponent", size: "btn-neutral")
+        = component_link("Cally Input", "Daisy::DataInput::CallyInputComponent")
         component.
 
   = daisy_input(id: "cally_input", placeholder: "Select a date...")

--- a/docs/demo/app/views/examples/daisy/data_input/cally_inputs.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/cally_inputs.html.haml
@@ -32,7 +32,7 @@
     :markdown
       You can customize the input or calendar by using the appropriate slots.
 
-  = daisy_cally_input(placeholder: "parent placeholder", popover_css: "dropdown-top dropdown-center") do |c|
+  = daisy_cally_input(placeholder: "parent placeholder", popover_css: "dropdown-top dropdown-center", auto_scroll_padding: 200) do |c|
     = c.with_input(placeholder: "Select a date...")
     = c.with_calendar(css: "bg-accent")
 
@@ -48,7 +48,7 @@
     .my-2.flex.flex-col.gap-4
       = form.daisy_cally_input(:start_date, start: "Start Date")
       = form.daisy_cally_input(:end_date, end: "End Date")
-      = form.daisy_cally_input(:event_date, placeholder: "Select an event date", floating: "Select an event date")
+      = form.daisy_cally_input(:event_date, floating_placeholder: "Select an event date")
 
       = form.daisy_label(:registration_deadline, "Registration Deadline", css: "mt-4")
       = form.daisy_cally_input(:registration_deadline, value: Date.today.next_month.to_s) do |cally|

--- a/docs/demo/app/views/examples/daisy/data_input/cally_inputs.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/cally_inputs.html.haml
@@ -1,0 +1,61 @@
+= doc_title(title: "Cally Inputs", comp: @comp) do |title|
+  %p
+    Cally Inputs combine a Daisy text input field with a Cally calendar using
+    the new HTML
+    = daisy_link(title: "Popover API ↗", target: "_blank", css: "whitespace-nowrap", href: "https://developer.mozilla.org/en-US/docs/Web/API/Popover_API")
+    for intuitive date selection.
+
+  %p
+    This component provides an elegant alternative to standard HTML date inputs
+    while maintaining a consistent visual style with other form components.
+
+
+= doc_example(title: "Basic Usage") do |doc|
+  - doc.with_description do
+    :markdown
+      The basic Cally Input provides a text field that, when clicked, displays a
+      calendar popover for date selection.
+
+    = doc_note(modifier: :tip, css: "mb-8") do
+      %p
+        For keyboard navigation, you can use the
+        = daisy_kbd("space")
+        or
+        = daisy_kbd("↓")
+        keys to open the calendar popover.
+
+  = daisy_cally_input(value: "2025-07-24")
+
+
+= doc_example(title: "Custom Input") do |doc|
+  - doc.with_description do
+    :markdown
+      You can customize the input or calendar by using the appropriate slots.
+
+  = daisy_cally_input(placeholder: "parent placeholder", popover_css: "dropdown-top dropdown-center") do |c|
+    = c.with_input(placeholder: "Select a date...")
+    = c.with_calendar(css: "bg-accent")
+
+
+= doc_example(title: "Rails Form Example") do |doc|
+  - doc.with_description do
+    :markdown
+      The built-in Form Builder extension makes it easy to use Cally Inputs in your
+      Rails forms. The component automatically extracts the name, ID, and value
+      attributes from the form object.
+
+  = form_with(url: "#", method: :post, scope: :event) do |form|
+    .my-2.flex.flex-col.gap-4
+      = form.daisy_cally_input(:start_date, start: "Start Date")
+      = form.daisy_cally_input(:end_date, end: "End Date")
+      = form.daisy_cally_input(:event_date, placeholder: "Select an event date", floating: "Select an event date")
+
+      = form.daisy_label(:registration_deadline, "Registration Deadline", css: "mt-4")
+      = form.daisy_cally_input(:registration_deadline, value: Date.today.next_month.to_s) do |cally|
+        - cally.with_input(placeholder: "Select a registration deadline...")
+
+      = form.daisy_label(:reminder_date, "Reminder Date", css: "mt-4")
+      = form.daisy_cally_input(:reminder_date, popover_css: "dropdown-top") do |cally|
+        - cally.with_input(placeholder: "Select a reminder date...")
+        - cally.with_calendar(css: "bg-secondary")
+

--- a/docs/demo/app/views/examples/daisy/data_input/fieldsets.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/fieldsets.html.haml
@@ -41,7 +41,7 @@
   = daisy_fieldset(legend: "User Profile") do
     .mt-4.space-y-4
       = daisy_input(floating: "Name")
-      = daisy_text_area(floating: "Bio", rows: 3)
+      = daisy_text_area(placeholder: "Bio", rows: 3) # Text areas don't currently support floating labels
       = daisy_select(floating: "Country", options: ["USA", "Canada", "Mexico"])
 
 

--- a/docs/demo/app/views/examples/daisy/data_input/labels.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/labels.html.haml
@@ -37,16 +37,14 @@
       markup.
 
     %p
-      - btn_attrs = { css: "btn-xs", right_icon: "cube", right_icon_css: "size-4", html: { data: { turbo: "false" }} }
-
       The
-      = daisy_button(title: "TextInput", href: "/examples/Daisy::DataInput::TextInputComponent", **btn_attrs)
+      = component_link("TextInput", "Daisy::DataInput::TextInputComponent")
       ,
-      = daisy_button(title: "Select", href: "/examples/Daisy::DataInput::SelectComponent", **btn_attrs)
+      = component_link("Select", "Daisy::DataInput::SelectComponent")
       ,
-      = daisy_button(title: "Checkbox", href: "/examples/Daisy::DataInput::CheckboxComponent", **btn_attrs)
+      = component_link("Checkbox", "Daisy::DataInput::CheckboxComponent")
       , and
-      = daisy_button(title: "Toggle", href: "/examples/Daisy::DataInput::ToggleComponent", **btn_attrs)
+      = component_link("Toggle", "Daisy::DataInput::ToggleComponent")
       components include this functionality.
 
   .my-2.flex.flex-col.gap-4

--- a/docs/demo/app/views/examples/daisy/data_input/labels.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/labels.html.haml
@@ -108,5 +108,5 @@
       methods for rendering Daisy Inputs with labels.
 
   = form_with(url: "#", class: "my-2 flex flex-col gap-4") do |f|
-    = f.daisy_text_input :name, floating: "Name", placeholder: "Name"
-    = f.daisy_text_input :email, type: :email, floating: "Email", placeholder: "Email"
+    = f.daisy_text_input :name, floating_placeholder: "Name"
+    = f.daisy_text_input :email, type: :email, floating_placeholder: "Email"

--- a/docs/demo/app/views/examples/daisy/data_input/selects.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/selects.html.haml
@@ -31,12 +31,14 @@
 
     = daisy_label(css: "mt-2", for: "right_label_select", title: "Country")
 
-    = daisy_select(name: "right_label_select", id: "right_label_select", placeholder: "Select a country", end: "Country") do |select|
-      - select.with_option(value: "us", label: "United States")
-      - select.with_option(value: "ca", label: "Canada")
-      - select.with_option(value: "mx", label: "Mexico")
+    = daisy_tip("DaisyUI end-labeled selects don't currently allow you to select the dropdown area.", css: "tooltip-warning") do
+      = daisy_select(name: "right_label_select", id: "right_label_select", placeholder: "Select a country", end: "Country") do |select|
+        - select.with_option(value: "us", label: "United States")
+        - select.with_option(value: "ca", label: "Canada")
+        - select.with_option(value: "mx", label: "Mexico")
 
-    = daisy_select(label_wrapper_css: "mt-8", name: "floating_label_select", id: "floating_label_select", include_blank: true, floating: "Country") do |select|
+    = daisy_select(label_wrapper_css: "mt-8", name: "floating_label_select", id: "floating_label_select", include_blank: true,
+                   floating: "Country", placeholder: "Select a country...") do |select|
       - select.with_option(value: "us", label: "United States")
       - select.with_option(value: "ca", label: "Canada")
       - select.with_option(value: "mx", label: "Mexico")
@@ -48,13 +50,24 @@
       For simpler cases, you can pass a list of strings as options. The value and
       label will both be set to the string value.
 
-  .my-2.space-y-2
-    = daisy_label(for: "simple_select", title: "Choose a Size")
-    = daisy_select(name: "simple_select", id: "simple_select", placeholder: "Select a size") do |select|
-      - select.with_option(value: "Small", label: "Small")
-      - select.with_option(value: "Medium", label: "Medium")
-      - select.with_option(value: "Large", label: "Large")
-      - select.with_option(value: "X-Large", label: "X-Large")
+      Or you can pass an array of Hashes. You can set the label and value keys
+      through the `option_label` and `option_value` parameters.
+
+  .flex.flex-col.gap-8
+    - tshirt_sizes = ["Small", "Medium", "Large", "X-Large"]
+    = daisy_select(css: "w-60", name: "tshirt_size", id: "tshirt_size",
+      floating: "Select a t-shirt size", options: tshirt_sizes)
+
+    :ruby
+      table_sizes = [
+        { code: "sm", display: "Small (fits 1-2 people)" },
+        { code: "md", display: "Medium (fits 2-4 people)" },
+        { code: "lg", display: "Large (fits 4-6 people)" },
+        { code: "xl", display: "X-Large (fits 6+ people)" }
+      ]
+
+    = daisy_select(name: "table_size", id: "table_size", floating: "Select a table size",
+      options: table_sizes, option_label: :display, option_value: :code)
 
 
 = doc_example(title: "Select Sizes") do |doc|

--- a/docs/demo/app/views/examples/daisy/data_input/selects.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/selects.html.haml
@@ -31,7 +31,7 @@
 
     = daisy_label(css: "mt-2", for: "right_label_select", title: "Country")
 
-    = daisy_tip("DaisyUI end-labeled selects don't currently allow you to select the dropdown area.", css: "tooltip-warning") do
+    = daisy_tip("DaisyUI end-labeled selects don't currently allow you to select the label area.", css: "tooltip-warning") do
       = daisy_select(name: "right_label_select", id: "right_label_select", placeholder: "Select a country", end: "Country") do |select|
         - select.with_option(value: "us", label: "United States")
         - select.with_option(value: "ca", label: "Canada")

--- a/docs/demo/app/views/examples/daisy/data_input/text_inputs.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/text_inputs.html.haml
@@ -69,6 +69,9 @@
 
     = daisy_label(for: "date", title: "Date", css: "mt-4")
     = daisy_text_input(name: "date", id: "date", type: "date")
+    .text-sm.text-right
+      %span{ class: "text-base-content/50" } See also:
+      = component_link("Cally Input", "Daisy::DataInput::CallyInputComponent")
 
     = daisy_label(for: "time", title: "Time", css: "mt-4")
     = daisy_text_input(name: "time", id: "time", type: "time")

--- a/docs/demo/app/views/examples/daisy/data_input/toggles.html.haml
+++ b/docs/demo/app/views/examples/daisy/data_input/toggles.html.haml
@@ -1,7 +1,7 @@
 = doc_title(title: "Toggles", comp: @comp) do |title|
   %p
     The Toggle component is a wrapper around the
-    = daisy_button(css: "btn-sm", title: "Checkbox", right_icon: "cube", right_icon_css: "size-4", href: "/examples/Daisy::DataInput::CheckboxComponent", html: { data: { turbo: "false" }})
+    = component_link("Checkbox", "Daisy::DataInput::CheckboxComponent")
     component that sets the <code>toggle</code> property to <code>true</code> by default, providing a switch-like appearance.
 
 

--- a/docs/demo/app/views/examples/daisy/feedback/tooltips.html.haml
+++ b/docs/demo/app/views/examples/daisy/feedback/tooltips.html.haml
@@ -1,3 +1,4 @@
+- # TODO: Make this a component and use it for the Labelable concern docs too
 - tippable_docs_url = "#{Rails.configuration.api_docs_host}/LocoMotion/Concerns/TippableComponent"
 - tippable_docs_button = daisy_button(css: "px-4 rounded-full btn-sm btn-info btn-outline hover:text-base-100!",
   title: "TippableComponent Docs",

--- a/docs/demo/app/views/examples/daisy/layout/drawers.html.haml
+++ b/docs/demo/app/views/examples/daisy/layout/drawers.html.haml
@@ -30,6 +30,14 @@
     :markdown
       The right drawer slides in from the right side of the screen.
 
+    = doc_note(modifier: :error, css: "mb-8", title: "Known Issue") do
+      :markdown
+        This example broke in the V5 transition and no longer works properly. We
+        are working to correct it.
+
+        See [Issue #53](https://github.com/profoundry-us/loco_motion/issues/53)
+        for more information.
+
   .relative.w-full.h-48
     = daisy_drawer(css: "drawer-end") do |drawer|
       - # The `ms-[-100rem] w-[stretch]` CSS is only used to fix the example and isn't normally needed

--- a/docs/demo/app/views/examples/daisy/mockup/frames.html.haml
+++ b/docs/demo/app/views/examples/daisy/mockup/frames.html.haml
@@ -2,7 +2,7 @@
   %p
     Frames showcase your work as if they were displayed in a window. This is
     very similar to the existing
-    = daisy_button(css: "btn-sm", title: "Browser", right_icon: "cube", right_icon_css: "size-4", href: "/examples/Daisy::Mockup::BrowserComponent", html: { data: { turbo: "false" }})
+    = component_link("Browser", "Daisy::Mockup::BrowserComponent")
     component but without some of the additional styling such as the browser
     toolbar.
 

--- a/docs/demo/app/views/examples/daisy/navigation/pagination.html.haml
+++ b/docs/demo/app/views/examples/daisy/navigation/pagination.html.haml
@@ -1,7 +1,7 @@
 = doc_title(title: "Pagination") do |title|
   %p
     Pagination can be implemented by utilizing the existing
-    = daisy_button(css: "btn-sm", title: "Join", right_icon: "cube", right_icon_css: "size-4", href: "/examples/Daisy::Layout::JoinComponent", html: { data: { turbo: "false" }})
+    = component_link("Join", "Daisy::Layout::JoinComponent")
     component.
 
 

--- a/docs/demo/package.json
+++ b/docs/demo/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/typography": "^0.0.0-insiders.632970e",
     "algoliasearch": "^5.21.0",
     "autoprefixer": "^10.4.18",
+    "cally": "^0.8.0",
     "daisyui": "^5.0.12",
     "esbuild": "^0.20.2",
     "instantsearch.js": "^4.78.0",

--- a/docs/demo/yarn.lock
+++ b/docs/demo/yarn.lock
@@ -518,6 +518,11 @@ algoliasearch@^5.21.0:
     "@algolia/requester-fetch" "5.21.0"
     "@algolia/requester-node-http" "5.21.0"
 
+atomico@^1.76.1:
+  version "1.79.2"
+  resolved "https://registry.yarnpkg.com/atomico/-/atomico-1.79.2.tgz#eebff0e65fe12fdf2d751f57ec66e8057e923ddc"
+  integrity sha512-mshhLRMeIltNYbnQnqgnrvJ/uDa8XDfTQcjw3ymOygQqwHIQ4Sp0LcNYMCbACkV3DtV+eDXb9szwU4qMUuGwYQ==
+
 autoprefixer@^10.4.18:
   version "10.4.18"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.18.tgz#fcb171a3b017be7cb5d8b7a825f5aacbf2045163"
@@ -546,6 +551,13 @@ browserslist@^4.23.0:
     electron-to-chromium "^1.4.668"
     node-releases "^2.0.14"
     update-browserslist-db "^1.0.13"
+
+cally@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/cally/-/cally-0.8.0.tgz#37afdbb98e1f2bfdca66f0a1636b3f3ab33c56ff"
+  integrity sha512-jvQ2QMrsZM/ZPG/LWTkJEUPrp/ew1uS2KjKA/E6ru7mVvTMY2JgSagci9IghLmuamFh1pDajrxXAX4Qgo4FHbw==
+  dependencies:
+    atomico "^1.76.1"
 
 caniuse-lite@^1.0.30001587, caniuse-lite@^1.0.30001591:
   version "1.0.30001599"

--- a/index.js
+++ b/index.js
@@ -1,4 +1,9 @@
+import CallyInputController from './app/components/daisy/data_input/cally_input_controller';
 import CountdownController from './app/components/daisy/data_display/countdown_controller';
 import ThemeController from './app/components/daisy/actions/theme_controller';
 
-export { CountdownController, ThemeController };
+export {
+  CallyInputController,
+  CountdownController,
+  ThemeController,
+};

--- a/lib/loco_motion.rb
+++ b/lib/loco_motion.rb
@@ -16,6 +16,7 @@ require "loco_motion/helpers"
 
 # Load patches
 require "loco_motion/patches/view_component/slotable_default_patch"
+require "loco_motion/patches/view_component/slot_loco_parent_patch"
 
 require "hero"
 require "daisy"

--- a/lib/loco_motion/base_component.rb
+++ b/lib/loco_motion/base_component.rb
@@ -41,6 +41,10 @@ class LocoMotion::BaseComponent < ViewComponent::Base
 
     # Allow certain components to skip styling if they are being inherited
     @skip_styling = config_option(:skip_styling, false)
+
+    # Allow manual passing of the loco parent on init if it's not auto-set
+    # via slots
+    @loco_parent = kws[:loco_parent] if kws.key?(:loco_parent)
   end
 
   #
@@ -411,6 +415,7 @@ class LocoMotion::BaseComponent < ViewComponent::Base
       "@valid_sizes=#{valid_sizes.inspect}",
       "@config=#{@config.inspect}",
       "@component_parts=#{parts.inspect}",
+      "@loco_parent=#{loco_parent.inspect}",
     ].join(" ") + ">"
   end
 end

--- a/lib/loco_motion/concerns/labelable_component.rb
+++ b/lib/loco_motion/concerns/labelable_component.rb
@@ -40,6 +40,9 @@ module LocoMotion
         renders_one :start
         renders_one :end
         renders_one :floating
+
+        # NOTE: We DO NOT define attr_reader properties here because it can
+        # cause confusion / problems with the parts and slots.
       end
 
       #
@@ -58,15 +61,28 @@ module LocoMotion
       # @option instance_kws [String, nil] :floating Text to display in the
       #   floating label position
       #
+      # @option instance_kws [String, nil] :placeholder The input's placeholder text.
+      #   If not provided and `floating_placeholder` is set, it will use that value.
+      #
+      # @option instance_kws [String, nil] :floating_placeholder Text to use for both
+      #   the floating label and the input placeholder. This is a convenience option
+      #   that sets both the `floating` and `placeholder` options to the same value.
+      #   If both `floating_placeholder` and `floating` are provided, `floating`
+      #   takes precedence for the floating label, while `floating_placeholder`
+      #   still sets the input's placeholder attribute.
+      #
       # @param instance_block [Proc] Block passed to the component for rendering
       #   custom content
       #
       def initialize(*instance_args, **instance_kws, &instance_block)
         super(*instance_args, **instance_kws, &instance_block)
 
+        @floating_placeholder = config_option(:floating_placeholder)
+
         @start = config_option(:start)
         @end = config_option(:end)
-        @floating = config_option(:floating)
+        @floating = config_option(:floating, @floating_placeholder)
+        @placeholder = config_option(:placeholder, @floating_placeholder)
       end
 
       #
@@ -101,7 +117,7 @@ module LocoMotion
       # @return [Boolean] true if start label is present, false otherwise
       #
       def has_start_label?
-        start? || config_option(:start).present?
+        start? || @start || config_option(:start).present?
       end
 
       #
@@ -110,7 +126,7 @@ module LocoMotion
       # @return [Boolean] true if end label is present, false otherwise
       #
       def has_end_label?
-        end? || config_option(:end).present?
+        end? || @end || config_option(:end).present?
       end
 
       #
@@ -119,7 +135,7 @@ module LocoMotion
       # @return [Boolean] true if floating label is present, false otherwise
       #
       def has_floating_label?
-        floating? || config_option(:floating).present?
+        floating? || @floating || config_option(:floating).present?
       end
     end
   end

--- a/lib/loco_motion/concerns/labelable_component.rb
+++ b/lib/loco_motion/concerns/labelable_component.rb
@@ -61,15 +61,15 @@ module LocoMotion
       # @option instance_kws [String, nil] :floating Text to display in the
       #   floating label position
       #
-      # @option instance_kws [String, nil] :placeholder The input's placeholder text.
-      #   If not provided and `floating_placeholder` is set, it will use that value.
+      # @option instance_kws [String, nil] :placeholder The input's placeholder
+      #   text.  If not provided and `floating_placeholder` is set, it will use
+      #   that value.
       #
-      # @option instance_kws [String, nil] :floating_placeholder Text to use for both
-      #   the floating label and the input placeholder. This is a convenience option
-      #   that sets both the `floating` and `placeholder` options to the same value.
-      #   If both `floating_placeholder` and `floating` are provided, `floating`
-      #   takes precedence for the floating label, while `floating_placeholder`
-      #   still sets the input's placeholder attribute.
+      # @option instance_kws [String, nil] :floating_placeholder Text to use for
+      #   both the floating label and the input placeholder. This is a
+      #   convenience option that sets both the `floating` and `placeholder`
+      #   options to the same value. Both `floating` and `placeholder` take
+      #   precedence over `floating_placeholder`.
       #
       # @param instance_block [Proc] Block passed to the component for rendering
       #   custom content

--- a/lib/loco_motion/helpers.rb
+++ b/lib/loco_motion/helpers.rb
@@ -32,6 +32,8 @@ module LocoMotion
     "Daisy::DataDisplay::TimelineComponent" => { names: "timeline", group: "Data Display", title: "Timelines", example: "timelines" },
 
     # Data Input
+    "Daisy::DataInput::CallyComponent" => { names: "cally", group: "Data Input", title: "Calendars", example: "calendars" },
+    "Daisy::DataInput::CallyInputComponent" => { names: "cally_input", group: "Data Input", title: "Cally Inputs", example: "cally_inputs" },
     "Daisy::DataInput::CheckboxComponent" => { names: "checkbox", group: "Data Input", title: "Checkboxes", example: "checkboxes" },
     "Daisy::DataInput::FileInputComponent" => { names: "file_input", group: "Data Input", title: "File Inputs", example: "file_inputs" },
     "Daisy::DataInput::FieldsetComponent" => { names: "fieldset", group: "Data Input", title: "Fieldsets", example: "fieldsets" },

--- a/lib/loco_motion/patches/view_component/slot_loco_parent_patch.rb
+++ b/lib/loco_motion/patches/view_component/slot_loco_parent_patch.rb
@@ -22,6 +22,7 @@ module LocoMotion
 
         def set_loco_parent(parent = @parent)
           return if parent.nil?
+          return if @__vc_component_instance.nil?
           return if @__vc_component_instance.loco_parent.present?
 
           @__vc_component_instance.set_loco_parent(parent)

--- a/lib/loco_motion/patches/view_component/slot_loco_parent_patch.rb
+++ b/lib/loco_motion/patches/view_component/slot_loco_parent_patch.rb
@@ -1,0 +1,36 @@
+# Monkey patch ViewComponent::Slot to save the parent component
+
+module LocoMotion
+  module Patches
+    module ViewComponent
+      module SlotPatch
+
+        # Set the loco parent any time the instance changes
+        def __vc_component_instance=(instance)
+          # Call the original implementation
+          super
+
+          # And set the Loco parent
+          set_loco_parent
+        end
+
+        def to_s
+          set_loco_parent
+
+          super
+        end
+
+        def set_loco_parent(parent = @parent)
+          return if parent.nil?
+          return if @__vc_component_instance.loco_parent.present?
+
+          @__vc_component_instance.set_loco_parent(parent)
+        end
+
+      end
+    end
+  end
+end
+
+# Apply the patch
+::ViewComponent::Slot.prepend(LocoMotion::Patches::ViewComponent::SlotPatch)

--- a/spec/components/daisy/actions/dropdown_component_spec.rb
+++ b/spec/components/daisy/actions/dropdown_component_spec.rb
@@ -204,33 +204,5 @@ RSpec.describe Daisy::Actions::DropdownComponent, type: :component do
     end
   end
 
-  context "with input" do
-    let(:dropdown) { described_class.new }
-    let(:placeholder_text) { "Search..." }
 
-    before do
-      render_inline(dropdown) do |d|
-        d.with_input(css: "w-full", placeholder: placeholder_text)
-      end
-    end
-
-    describe "rendering" do
-      it "renders a text input field" do
-        expect(page).to have_css "input[type=text]"
-      end
-
-      it "applies custom classes to the input" do
-        expect(page).to have_css "input.input.w-full"
-      end
-
-      it "includes the placeholder text" do
-        expect(page).to have_css "input[placeholder=\"#{placeholder_text}\"]"
-      end
-
-      it "places the input in the dropdown content" do
-        dropdown_html = page.find(".dropdown").native.inner_html
-        expect(dropdown_html).to include("input")
-      end
-    end
-  end
 end

--- a/spec/components/daisy/actions/dropdown_component_spec.rb
+++ b/spec/components/daisy/actions/dropdown_component_spec.rb
@@ -203,4 +203,34 @@ RSpec.describe Daisy::Actions::DropdownComponent, type: :component do
       end
     end
   end
+
+  context "with input" do
+    let(:dropdown) { described_class.new }
+    let(:placeholder_text) { "Search..." }
+
+    before do
+      render_inline(dropdown) do |d|
+        d.with_input(css: "w-full", placeholder: placeholder_text)
+      end
+    end
+
+    describe "rendering" do
+      it "renders a text input field" do
+        expect(page).to have_css "input[type=text]"
+      end
+
+      it "applies custom classes to the input" do
+        expect(page).to have_css "input.input.w-full"
+      end
+
+      it "includes the placeholder text" do
+        expect(page).to have_css "input[placeholder=\"#{placeholder_text}\"]"
+      end
+
+      it "places the input in the dropdown content" do
+        dropdown_html = page.find(".dropdown").native.inner_html
+        expect(dropdown_html).to include("input")
+      end
+    end
+  end
 end

--- a/spec/components/daisy/actions/dropdown_component_spec.rb
+++ b/spec/components/daisy/actions/dropdown_component_spec.rb
@@ -204,5 +204,4 @@ RSpec.describe Daisy::Actions::DropdownComponent, type: :component do
     end
   end
 
-
 end

--- a/spec/components/daisy/data_display/figure_component_spec.rb
+++ b/spec/components/daisy/data_display/figure_component_spec.rb
@@ -49,4 +49,17 @@ RSpec.describe Daisy::DataDisplay::FigureComponent, type: :component do
       expect(page).to have_selector("figure.custom-class")
     end
   end
+
+  context "with both src and content" do
+    let(:figure) { described_class.new(src: "example.jpg") }
+
+    before do
+      render_inline(figure) { "Figure caption" }
+    end
+
+    it "renders both the image and content" do
+      expect(page).to have_selector("img[src='example.jpg']")
+      expect(page).to have_selector("figure", text: "Figure caption")
+    end
+  end
 end

--- a/spec/components/daisy/data_input/cally_component_spec.rb
+++ b/spec/components/daisy/data_input/cally_component_spec.rb
@@ -112,32 +112,26 @@ RSpec.describe Daisy::DataInput::CallyComponent, type: :component do
     end
 
     it "renders custom previous icon" do
-      expect(page).to have_css("[slot='previous']")
-      # Hero icon is likely be stubbed in test mode, so we'll check for the slot attribute
-      # rather than the specific SVG content
+      expect(page).to have_css("svg[data-slot='icon'][slot='previous']")
     end
 
     it "renders custom next icon" do
-      expect(page).to have_css("[slot='next']")
-      # Hero icon is likely be stubbed in test mode, so we'll check for the slot attribute
-      # rather than the specific SVG content
+      expect(page).to have_css("svg[data-slot='icon'][slot='next']")
     end
   end
 
   context "with custom months" do
-    # Stub the rendering of months for testing
-    # In tests, the custom elements may not be fully processed as they would be in a browser
     it "allows adding multiple months" do
       component = described_class.new
-      
+
       # Add two months
       component.with_month(offset: 0)
       component.with_month(offset: 1)
-      
+
       # Verify two months were added
       expect(component.months.size).to eq(2)
     end
-    
+
     it "creates month components with proper initialization" do
       # Test the MonthComponent directly
       month = Daisy::DataInput::CallyComponent::MonthComponent.new(offset: 1)

--- a/spec/components/daisy/data_input/cally_component_spec.rb
+++ b/spec/components/daisy/data_input/cally_component_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Daisy::DataInput::CallyComponent, type: :component do
+  context "basic rendering" do
+    let(:component) { described_class.new }
+
+    before do
+      render_inline(component)
+    end
+
+    it "renders a calendar component" do
+      expect(page).to have_css("calendar-date.cally")
+    end
+
+    it "renders default icons" do
+      expect(page).to have_css("[slot='previous']")
+      expect(page).to have_css("[slot='next']")
+    end
+  end
+
+  context "with range modifier" do
+    let(:component) { described_class.new(modifiers: [:range]) }
+
+    before do
+      render_inline(component)
+    end
+
+    it "renders a range calendar" do
+      expect(page).to have_css("calendar-range.cally")
+    end
+  end
+
+  context "with configuration options" do
+    let(:component) do
+      described_class.new(
+        id: "test-calendar",
+        value: "2025-05-15",
+        min: "2025-01-01",
+        max: "2025-12-31",
+        today: "2025-05-15",
+        months: 2
+      )
+    end
+
+    before do
+      render_inline(component)
+    end
+
+    it "sets the id attribute" do
+      expect(page).to have_css("calendar-date[id='test-calendar']")
+    end
+
+    it "sets the value attribute" do
+      expect(page).to have_css("calendar-date[value='2025-05-15']")
+    end
+
+    it "sets the min attribute" do
+      expect(page).to have_css("calendar-date[min='2025-01-01']")
+    end
+
+    it "sets the max attribute" do
+      expect(page).to have_css("calendar-date[max='2025-12-31']")
+    end
+
+    it "sets the today attribute" do
+      expect(page).to have_css("calendar-date[today='2025-05-15']")
+    end
+
+    it "sets the months attribute" do
+      expect(page).to have_css("calendar-date[months='2']")
+    end
+  end
+
+  context "with change option" do
+    let(:component) do
+      described_class.new(change: "target-input")
+    end
+
+    before do
+      render_inline(component)
+    end
+
+    it "sets the onchange handler for the input target" do
+      expect(page.native.to_html).to include("onchange=\"document.getElementById('target-input').value = this.value\"")
+    end
+  end
+
+  context "with update option" do
+    let(:component) do
+      described_class.new(update: "target-display")
+    end
+
+    before do
+      render_inline(component)
+    end
+
+    it "sets the onchange handler for the display target" do
+      expect(page.native.to_html).to include("onchange=\"document.getElementById('target-display').innerHTML = this.value\"")
+    end
+  end
+
+  context "with custom icons" do
+    let(:component) { described_class.new }
+
+    before do
+      render_inline(component) do |c|
+        c.with_previous_icon(icon: "arrow-left")
+        c.with_next_icon(icon: "arrow-right")
+      end
+    end
+
+    it "renders custom previous icon" do
+      expect(page).to have_css("[slot='previous']")
+      # Hero icon is likely be stubbed in test mode, so we'll check for the slot attribute
+      # rather than the specific SVG content
+    end
+
+    it "renders custom next icon" do
+      expect(page).to have_css("[slot='next']")
+      # Hero icon is likely be stubbed in test mode, so we'll check for the slot attribute
+      # rather than the specific SVG content
+    end
+  end
+
+  context "with custom months" do
+    # Stub the rendering of months for testing
+    # In tests, the custom elements may not be fully processed as they would be in a browser
+    it "allows adding multiple months" do
+      component = described_class.new
+      
+      # Add two months
+      component.with_month(offset: 0)
+      component.with_month(offset: 1)
+      
+      # Verify two months were added
+      expect(component.months.size).to eq(2)
+    end
+    
+    it "creates month components with proper initialization" do
+      # Test the MonthComponent directly
+      month = Daisy::DataInput::CallyComponent::MonthComponent.new(offset: 1)
+      expect(month.instance_variable_get(:@offset)).to eq(1)
+    end
+  end
+
+  context "month_options method" do
+    let(:component) { described_class.new }
+
+    it "returns empty hash for index 0" do
+      expect(component.month_options(0)).to eq({})
+    end
+
+    it "returns hash with offset for index > 0" do
+      expect(component.month_options(1)).to eq({ offset: 1 })
+      expect(component.month_options(2)).to eq({ offset: 2 })
+    end
+  end
+
+  context "with MonthComponent" do
+    let(:month_component) { Daisy::DataInput::CallyComponent::MonthComponent.new(offset: 2) }
+
+    before do
+      render_inline(month_component)
+    end
+
+    it "renders a calendar-month tag" do
+      expect(page).to have_css("calendar-month[offset='2']")
+    end
+  end
+
+  context "with PreviousIcon and NextIcon" do
+    let(:previous_icon) { Daisy::DataInput::CallyComponent::PreviousIcon.new(icon: "chevron-left") }
+    let(:next_icon) { Daisy::DataInput::CallyComponent::NextIcon.new(icon: "chevron-right") }
+
+    it "sets slot attribute for PreviousIcon" do
+      render_inline(previous_icon)
+      expect(page).to have_css("[slot='previous']")
+    end
+
+    it "sets slot attribute for NextIcon" do
+      render_inline(next_icon)
+      expect(page).to have_css("[slot='next']")
+    end
+  end
+
+  context "default icons methods" do
+    let(:component) { described_class.new }
+
+    it "default_previous_icon returns PreviousIcon with chevron-left" do
+      icon = component.default_previous_icon
+      expect(icon).to be_a(Daisy::DataInput::CallyComponent::PreviousIcon)
+      expect(icon.instance_variable_get(:@icon)).to eq("chevron-left")
+    end
+
+    it "default_next_icon returns NextIcon with chevron-right" do
+      icon = component.default_next_icon
+      expect(icon).to be_a(Daisy::DataInput::CallyComponent::NextIcon)
+      expect(icon.instance_variable_get(:@icon)).to eq("chevron-right")
+    end
+  end
+end

--- a/spec/components/daisy/data_input/cally_input_component_spec.rb
+++ b/spec/components/daisy/data_input/cally_input_component_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Daisy::DataInput::CallyInputComponent, type: :component do
+  # Basic rendering
+  context "basic rendering" do
+    let(:component) { described_class.new }
+
+    before do
+      render_inline(component)
+    end
+
+    it "renders the input" do
+      expect(page).to have_css("input.input")
+    end
+
+    it "renders the calendar in a popover" do
+      expect(page).to have_css("[popover='auto'] calendar-date")
+    end
+
+    it "includes the stimulus controller" do
+      expect(page).to have_css("[data-controller='cally-input']")
+    end
+
+    it "sets up data attributes for stimulus targets" do
+      expect(page).to have_css("[data-cally-input-target='input']")
+      expect(page).to have_css("[data-cally-input-target='calendar']")
+      expect(page).to have_css("[data-cally-input-target='popover']")
+    end
+  end
+
+  # Testing with predefined values
+  context "with provided values" do
+    let(:custom_id) { "custom-cally-id" }
+    let(:date_value) { "2025-05-15" }
+    let(:component) { described_class.new(id: custom_id, value: date_value) }
+
+    before do
+      render_inline(component)
+    end
+
+    it "uses the provided ID" do
+      expect(page).to have_css("[id='#{custom_id}']")
+    end
+
+    it "sets the value on the input" do
+      expect(page).to have_css("input[value='#{date_value}']")
+    end
+
+    it "sets the value on the calendar" do
+      expect(page).to have_css("calendar-date[value='#{date_value}']")
+    end
+  end
+
+  # Testing reader methods
+  context "component attribute readers" do
+    let(:custom_id) { "reader-test-id" }
+    let(:date_value) { "2025-12-31" }
+    let(:component) { described_class.new(id: custom_id, value: date_value) }
+
+    it "provides access to id" do
+      expect(component.id).to eq(custom_id)
+    end
+
+    it "provides access to value" do
+      expect(component.value).to eq(date_value)
+    end
+
+    it "provides access to derived IDs" do
+      # The input ID no longer adds the -input suffix
+      expect(component.input_id).to eq(custom_id)
+
+      expect(component.calendar_id).to eq("#{custom_id}-calendar")
+      expect(component.popover_id).to eq("#{custom_id}-popover")
+      expect(component.anchor).to eq("#{custom_id}-anchor")
+    end
+  end
+
+  # Testing default components
+  context "default components" do
+    let(:component) { described_class.new }
+
+    it "provides a default calendar" do
+      expect(component.default_calendar).to be_an_instance_of(Daisy::DataInput::CallyInputComponent::CallyCalendarComponent)
+    end
+
+    it "provides a default input" do
+      expect(component.default_input).to be_an_instance_of(Daisy::DataInput::CallyInputComponent::CallyTextInputComponent)
+    end
+  end
+
+  # Testing slot overrides
+  context "with custom input slot" do
+    let(:custom_id) { "custom-id" }
+    let(:custom_name) { "custom_name" }
+    let(:custom_placeholder) { "Select a date..." }
+    let(:component) do
+      described_class.new(id: "parent-id", name: "parent_name", placeholder: "Parent placeholder")
+    end
+
+    before do
+      render_inline(component) do |c|
+        c.with_input(id: custom_id, name: custom_name, placeholder: custom_placeholder)
+      end
+    end
+
+    it "uses the overridden id from the slot" do
+      expect(page).to have_css("##{custom_id}")
+    end
+
+    it "uses the overridden name from the slot" do
+      expect(page).to have_css("input[name='#{custom_name}']")
+    end
+
+    it "uses the overridden placeholder from the slot" do
+      expect(page).to have_css("input[placeholder='#{custom_placeholder}']")
+    end
+
+    it "still maintains the popover target" do
+      expect(page).to have_css("input[popovertarget$='-popover']")
+    end
+  end
+
+  # Testing default values when no slot overrides are provided
+  context "without slot overrides" do
+    let(:component) { described_class.new(id: "parent-id", name: "parent_name", placeholder: "Default placeholder") }
+
+    before do
+      render_inline(component)
+    end
+
+    it "uses the parent id when not overridden" do
+      expect(page).to have_css("#parent-id")
+    end
+
+    it "uses the parent name when not overridden" do
+      expect(page).to have_css("input[name='parent_name']")
+    end
+
+    it "uses the parent placeholder when not overridden" do
+      expect(page).to have_css("input[placeholder='Default placeholder']")
+    end
+  end
+end

--- a/spec/components/daisy/data_input/filter_component_spec.rb
+++ b/spec/components/daisy/data_input/filter_component_spec.rb
@@ -139,9 +139,7 @@ RSpec.describe Daisy::DataInput::FilterComponent, type: :component do
         options: ["Option 1", "Option 2"]
       )
 
-      # Render and debug the output
-      result = render_inline(component).to_html
-      puts "\nRendered HTML:\n#{result}\n"
+      render_inline(component)
 
       # Check that each option has automatically generated IDs with index
       expect(page).to have_css("input[id='parent-filter_0']")

--- a/spec/helpers/daisy/form_builder_helper_spec.rb
+++ b/spec/helpers/daisy/form_builder_helper_spec.rb
@@ -307,7 +307,7 @@ RSpec.describe Daisy::FormBuilderHelper, type: :helper do
         expect(builder).to receive(:object).and_return(nil)
         expect(template).to receive(:render) do |component|
           expect(component.type).to eq("email")
-          expect(component.placeholder).to eq("Enter your email")
+          expect(component.config_option(:placeholder)).to eq("Enter your email")
         end
 
         builder.daisy_text_input("email", type: "email", placeholder: "Enter your email")


### PR DESCRIPTION
## Context
This PR introduces the new Daisy Cally component, a date picker input with enhanced floating label support. The implementation includes both the core calendar component and an input component that works seamlessly with it, following DaisyUI 5 design patterns.

## Related Issues
- Fixes [Add new DaisyUI 5 Calendar component #31](https://github.com/profoundry-us/loco_motion/issues/31)

## Type of Change
- New feature (non-breaking change which adds functionality)
- Component update/addition

## Description

### New Components
- CallyComponent: A reusable calendar component with month navigation
- CallyInputComponent: A text input with integrated calendar picker
- Stimulus Controller: Handles the interaction between input and calendar

### Key Features
- Floating Label Support: Uses zero-width spaces for smooth label transitions without flicker
- Keyboard Navigation: Full keyboard support for accessibility (arrow keys, space, enter)
- Responsive Design: Works across different screen sizes with auto-scrolling to keep the calendar in view
- Customizable: Supports custom icons, date formats, and styling
- Integrates with the LabelableComponent concern for consistent form handling

### Technical Details
- Uses HTML's native popover API for better performance and accessibility
- Implements Stimulus.js for interactive behavior with comprehensive event handling
- Follows DaisyUI 5 design patterns with built-in border styling
- Includes comprehensive test coverage
- Maintains focus appropriately when navigating between input and calendar
- Properly handles edge cases like empty inputs with floating labels

### Other Changes
- Fixed issues with figures not showing captions
- Fixed fieldset textarea rendering issues
- Added error modifier to doc_note component for improved documentation
- Fixed typos in select documentation
- Added check in set_loco_parent_patch to ensure we catch nil references
- Used shorthand floating_placeholder for label examples
- Fixed bug in boxed countdown example
- Added todos about better API doc buttons

### Screenshots
<img width="1458" alt="Screenshot 2025-05-17 at 5 50 06 PM" src="https://github.com/user-attachments/assets/729c5a6f-af97-4420-b451-bd5eee70dcc3" />

<img width="1457" alt="Screenshot 2025-05-17 at 5 49 50 PM" src="https://github.com/user-attachments/assets/e7d8bca5-7aba-4427-ada8-f1fdb4919161" />
