### PR TITLE
Fix #53 - Update DaisyUI and modify Right Drawer example.

### DIFF
--- a/docs/demo/app/views/examples/daisy/layout/drawers.html.haml
+++ b/docs/demo/app/views/examples/daisy/layout/drawers.html.haml
@@ -30,19 +30,16 @@
     :markdown
       The right drawer slides in from the right side of the screen.
 
-    = doc_note(modifier: :error, css: "mb-8", title: "Known Issue") do
+    = doc_note(modifier: :warning, css: "mb-8", title: "Multiple Drawers") do
       :markdown
-        This example broke in the V5 transition and no longer works properly. We
-        are working to correct it.
+        Drawers are not designed to work with multiple on the page, so this
+        example behaves a bit weirdly on desktop, showing both drawers.
 
-        See [Issue #53](https://github.com/profoundry-us/loco_motion/issues/53)
-        for more information.
-
-  .relative.w-full.h-48
+  .w-full.h-48
     = daisy_drawer(css: "drawer-end") do |drawer|
-      - # The `ms-[-100rem] w-[stretch]` CSS is only used to fix the example and isn't normally needed
-      - drawer.with_sidebar(css: "absolute ms-[-100rem] w-[stretch] h-48") do
-        .bg-base-100.p-4.w-40.h-48
+      - drawer.with_sidebar do
+        - # The calc accounts for the top nav bar
+        .w-48.bg-base-100.mt-16.p-4{ class: "h-[calc(100%-4rem)]" }
           Right sidebar!
 
       = daisy_button(tag_name: "label", css: "m-8 btn btn-primary", title: "Open Drawer", html: { for: drawer.id })

--- a/docs/demo/package.json
+++ b/docs/demo/package.json
@@ -14,7 +14,7 @@
     "algoliasearch": "^5.21.0",
     "autoprefixer": "^10.4.18",
     "cally": "^0.8.0",
-    "daisyui": "^5.0.12",
+    "daisyui": "^5.0.43",
     "esbuild": "^0.20.2",
     "instantsearch.js": "^4.78.0",
     "tailwindcss": "^4.1.8"

--- a/docs/demo/yarn.lock
+++ b/docs/demo/yarn.lock
@@ -692,10 +692,10 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-daisyui@^5.0.12:
-  version "5.0.12"
-  resolved "https://registry.yarnpkg.com/daisyui/-/daisyui-5.0.12.tgz#00c684b664cefa292aa0399bf1dcd76af415b291"
-  integrity sha512-01DU0eYBcHgPtuf5fxcrkGkIN6/Uyaqmkle5Yo3ZyW9YVAu036ALZbjv2KH5euvUbeQ4r9q3gAarGcf7Tywhng==
+daisyui@^5.0.43:
+  version "5.0.43"
+  resolved "https://registry.yarnpkg.com/daisyui/-/daisyui-5.0.43.tgz#9c1ce45c8967825dc88330f1dfdfcd670c60d8d9"
+  integrity sha512-2pshHJ73vetSpsbAyaOncGnNYL0mwvgseS1EWy1I9Qpw8D11OuBoDNIWrPIME4UFcq2xuff3A9x+eXbuFR9fUQ==
 
 detect-libc@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## Context

With the upgrade to Daisy 5, the right Drawer example broke.

## Related Issues

Fixes #53

## Type of Change
<!-- Mark the appropriate option with an 'x' (no spaces) -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Component update/addition
- [ ] Test update/addition
- [ ] Other (please describe):

## Description

- Update Daisy UI to latest point version (5.0.43)
- Rework Right Drawer example to work a bit better
- Change Right Drawer error message to a warning about using multiple drawers

## Checklist
<!-- Mark completed items with an 'x' (no spaces) -->
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] I have verified my changes in the browser (if applicable)
- [ ] I have added appropriate YARD documentation (if applicable)
- [x] I have followed the project's documentation standards
- [x] I have reviewed my own code for potential improvements

## Additional Notes
<!-- Add any additional notes, screenshots, or context about the changes -->
